### PR TITLE
Feature/#92 조회수, 풀이수 통계 업데이트 공통 서비스 구현

### DIFF
--- a/src/main/generated/com/moplus/moplus_server/statistic/Problem/domain/QChildProblemStatistic.java
+++ b/src/main/generated/com/moplus/moplus_server/statistic/Problem/domain/QChildProblemStatistic.java
@@ -1,0 +1,53 @@
+package com.moplus.moplus_server.statistic.Problem.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QChildProblemStatistic is a Querydsl query type for ChildProblemStatistic
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QChildProblemStatistic extends EntityPathBase<ChildProblemStatistic> {
+
+    private static final long serialVersionUID = 1136828573L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QChildProblemStatistic childProblemStatistic = new QChildProblemStatistic("childProblemStatistic");
+
+    public final NumberPath<Long> childProblemId = createNumber("childProblemId", Long.class);
+
+    public final QCountStatistic countStatistic;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public QChildProblemStatistic(String variable) {
+        this(ChildProblemStatistic.class, forVariable(variable), INITS);
+    }
+
+    public QChildProblemStatistic(Path<? extends ChildProblemStatistic> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QChildProblemStatistic(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QChildProblemStatistic(PathMetadata metadata, PathInits inits) {
+        this(ChildProblemStatistic.class, metadata, inits);
+    }
+
+    public QChildProblemStatistic(Class<? extends ChildProblemStatistic> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.countStatistic = inits.isInitialized("countStatistic") ? new QCountStatistic(forProperty("countStatistic")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/moplus/moplus_server/statistic/Problem/domain/QCountStatistic.java
+++ b/src/main/generated/com/moplus/moplus_server/statistic/Problem/domain/QCountStatistic.java
@@ -1,0 +1,39 @@
+package com.moplus.moplus_server.statistic.Problem.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QCountStatistic is a Querydsl query type for CountStatistic
+ */
+@Generated("com.querydsl.codegen.DefaultEmbeddableSerializer")
+public class QCountStatistic extends BeanPath<CountStatistic> {
+
+    private static final long serialVersionUID = 1047466257L;
+
+    public static final QCountStatistic countStatistic = new QCountStatistic("countStatistic");
+
+    public final NumberPath<Long> submitCount = createNumber("submitCount", Long.class);
+
+    public final NumberPath<Long> viewCount = createNumber("viewCount", Long.class);
+
+    public QCountStatistic(String variable) {
+        super(CountStatistic.class, forVariable(variable));
+    }
+
+    public QCountStatistic(Path<? extends CountStatistic> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QCountStatistic(PathMetadata metadata) {
+        super(CountStatistic.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/moplus/moplus_server/statistic/Problem/domain/QProblemSetStatistic.java
+++ b/src/main/generated/com/moplus/moplus_server/statistic/Problem/domain/QProblemSetStatistic.java
@@ -1,0 +1,53 @@
+package com.moplus.moplus_server.statistic.Problem.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QProblemSetStatistic is a Querydsl query type for ProblemSetStatistic
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QProblemSetStatistic extends EntityPathBase<ProblemSetStatistic> {
+
+    private static final long serialVersionUID = -1319940803L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QProblemSetStatistic problemSetStatistic = new QProblemSetStatistic("problemSetStatistic");
+
+    public final QCountStatistic countStatistic;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final NumberPath<Long> problemSetId = createNumber("problemSetId", Long.class);
+
+    public QProblemSetStatistic(String variable) {
+        this(ProblemSetStatistic.class, forVariable(variable), INITS);
+    }
+
+    public QProblemSetStatistic(Path<? extends ProblemSetStatistic> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QProblemSetStatistic(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QProblemSetStatistic(PathMetadata metadata, PathInits inits) {
+        this(ProblemSetStatistic.class, metadata, inits);
+    }
+
+    public QProblemSetStatistic(Class<? extends ProblemSetStatistic> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.countStatistic = inits.isInitialized("countStatistic") ? new QCountStatistic(forProperty("countStatistic")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/moplus/moplus_server/statistic/Problem/domain/QProblemStatistic.java
+++ b/src/main/generated/com/moplus/moplus_server/statistic/Problem/domain/QProblemStatistic.java
@@ -1,0 +1,53 @@
+package com.moplus.moplus_server.statistic.Problem.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QProblemStatistic is a Querydsl query type for ProblemStatistic
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QProblemStatistic extends EntityPathBase<ProblemStatistic> {
+
+    private static final long serialVersionUID = 843488641L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QProblemStatistic problemStatistic = new QProblemStatistic("problemStatistic");
+
+    public final QCountStatistic countStatistic;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final NumberPath<Long> problemId = createNumber("problemId", Long.class);
+
+    public QProblemStatistic(String variable) {
+        this(ProblemStatistic.class, forVariable(variable), INITS);
+    }
+
+    public QProblemStatistic(Path<? extends ProblemStatistic> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QProblemStatistic(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QProblemStatistic(PathMetadata metadata, PathInits inits) {
+        this(ProblemStatistic.class, metadata, inits);
+    }
+
+    public QProblemStatistic(Class<? extends ProblemStatistic> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.countStatistic = inits.isInitialized("countStatistic") ? new QCountStatistic(forProperty("countStatistic")) : null;
+    }
+
+}
+

--- a/src/main/java/com/moplus/moplus_server/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/moplus/moplus_server/global/error/exception/ErrorCode.java
@@ -76,6 +76,11 @@ public enum ErrorCode {
     ALREADY_PUBLISHED_ERROR(HttpStatus.BAD_REQUEST, "이미 발행된 문항세트는 컨펌해제할 수 없습니다."),
     PROBLEM_SET_DELETED(HttpStatus.BAD_REQUEST, "삭제된 문항세트는 발행할 수 없습니다"),
     PROBLEM_SET_NOT_CONFIRMED(HttpStatus.BAD_REQUEST, "컨펌되지 않은 문항세트는 발행할 수 없습니다"),
+
+    // 통계
+    PROBLEM_STATISTIC_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 문항의 통계 정보를 찾을 수 없습니다"),
+    PROBLEM_SET_STATISTIC_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 문항세트의 통계 정보를 찾을 수 없습니다"),
+    CHILD_PROBLEM_STATISTIC_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 새끼 문항의 통계 정보를 찾을 수 없습니다"),
     ;
 
 

--- a/src/main/java/com/moplus/moplus_server/statistic/Problem/domain/ChildProblemStatistic.java
+++ b/src/main/java/com/moplus/moplus_server/statistic/Problem/domain/ChildProblemStatistic.java
@@ -1,0 +1,32 @@
+package com.moplus.moplus_server.statistic.Problem.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChildProblemStatistic {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "child_problem_statistic_id")
+    private Long id;
+
+    private Long childProblemId;
+
+    @Embedded
+    private CountStatistic countStatistic;
+
+    public ChildProblemStatistic(Long childProblemId) {
+        this.childProblemId = childProblemId;
+        this.countStatistic = new CountStatistic();
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/statistic/Problem/domain/ChildProblemStatistic.java
+++ b/src/main/java/com/moplus/moplus_server/statistic/Problem/domain/ChildProblemStatistic.java
@@ -39,4 +39,12 @@ public class ChildProblemStatistic implements StatisticCounter {
     public void addSubmitCount() {
         this.countStatistic.addSubmitCount();
     }
+
+    public Long getViewCount() {
+        return this.countStatistic.getViewCount();
+    }
+
+    public Long getSubmitCount() {
+        return this.countStatistic.getSubmitCount();
+    }
 }

--- a/src/main/java/com/moplus/moplus_server/statistic/Problem/domain/ChildProblemStatistic.java
+++ b/src/main/java/com/moplus/moplus_server/statistic/Problem/domain/ChildProblemStatistic.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ChildProblemStatistic {
+public class ChildProblemStatistic implements StatisticCounter {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -28,5 +28,15 @@ public class ChildProblemStatistic {
     public ChildProblemStatistic(Long childProblemId) {
         this.childProblemId = childProblemId;
         this.countStatistic = new CountStatistic();
+    }
+
+    @Override
+    public void addViewCount() {
+        this.countStatistic.addViewCount();
+    }
+
+    @Override
+    public void addSubmitCount() {
+        this.countStatistic.addSubmitCount();
     }
 }

--- a/src/main/java/com/moplus/moplus_server/statistic/Problem/domain/CountStatistic.java
+++ b/src/main/java/com/moplus/moplus_server/statistic/Problem/domain/CountStatistic.java
@@ -1,7 +1,9 @@
 package com.moplus.moplus_server.statistic.Problem.domain;
 
 import jakarta.persistence.Embeddable;
+import lombok.Getter;
 
+@Getter
 @Embeddable
 public class CountStatistic implements StatisticCounter {
     private Long viewCount;

--- a/src/main/java/com/moplus/moplus_server/statistic/Problem/domain/CountStatistic.java
+++ b/src/main/java/com/moplus/moplus_server/statistic/Problem/domain/CountStatistic.java
@@ -1,0 +1,14 @@
+package com.moplus.moplus_server.statistic.Problem.domain;
+
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class CountStatistic {
+    private Long viewCount;
+    private Long submitCount;
+
+    public CountStatistic() {
+        this.viewCount = 0L;
+        this.submitCount = 0L;
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/statistic/Problem/domain/CountStatistic.java
+++ b/src/main/java/com/moplus/moplus_server/statistic/Problem/domain/CountStatistic.java
@@ -3,12 +3,22 @@ package com.moplus.moplus_server.statistic.Problem.domain;
 import jakarta.persistence.Embeddable;
 
 @Embeddable
-public class CountStatistic {
+public class CountStatistic implements StatisticCounter {
     private Long viewCount;
     private Long submitCount;
 
     public CountStatistic() {
         this.viewCount = 0L;
         this.submitCount = 0L;
+    }
+
+    @Override
+    public void addViewCount() {
+        this.viewCount++;
+    }
+
+    @Override
+    public void addSubmitCount() {
+        this.submitCount++;
     }
 }

--- a/src/main/java/com/moplus/moplus_server/statistic/Problem/domain/CountUpper.java
+++ b/src/main/java/com/moplus/moplus_server/statistic/Problem/domain/CountUpper.java
@@ -1,4 +1,0 @@
-package com.moplus.moplus_server.statistic.Problem.domain;
-
-public interface CountUpper {
-}

--- a/src/main/java/com/moplus/moplus_server/statistic/Problem/domain/CountUpper.java
+++ b/src/main/java/com/moplus/moplus_server/statistic/Problem/domain/CountUpper.java
@@ -1,0 +1,4 @@
+package com.moplus.moplus_server.statistic.Problem.domain;
+
+public interface CountUpper {
+}

--- a/src/main/java/com/moplus/moplus_server/statistic/Problem/domain/ProblemSetStatistic.java
+++ b/src/main/java/com/moplus/moplus_server/statistic/Problem/domain/ProblemSetStatistic.java
@@ -1,6 +1,7 @@
 package com.moplus.moplus_server.statistic.Problem.domain;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -12,7 +13,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ProblemSetStatistic {
+public class ProblemSetStatistic implements StatisticCounter {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -23,9 +24,22 @@ public class ProblemSetStatistic {
     private Long viewCount;
     private Long submitCount;
 
+    @Embedded
+    private CountStatistic countStatistic;
+
     public ProblemSetStatistic(Long problemSetId, Long viewCount, Long submitCount) {
         this.problemSetId = problemSetId;
         this.viewCount = viewCount;
         this.submitCount = submitCount;
+    }
+
+    @Override
+    public void addViewCount() {
+        this.countStatistic.addViewCount();
+    }
+
+    @Override
+    public void addSubmitCount() {
+        this.countStatistic.addSubmitCount();
     }
 }

--- a/src/main/java/com/moplus/moplus_server/statistic/Problem/domain/ProblemSetStatistic.java
+++ b/src/main/java/com/moplus/moplus_server/statistic/Problem/domain/ProblemSetStatistic.java
@@ -1,0 +1,31 @@
+package com.moplus.moplus_server.statistic.Problem.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProblemSetStatistic {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "problem_set_statistic_id")
+    private Long id;
+
+    private Long problemSetId;
+    private Long viewCount;
+    private Long submitCount;
+
+    public ProblemSetStatistic(Long problemSetId, Long viewCount, Long submitCount) {
+        this.problemSetId = problemSetId;
+        this.viewCount = viewCount;
+        this.submitCount = submitCount;
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/statistic/Problem/domain/ProblemSetStatistic.java
+++ b/src/main/java/com/moplus/moplus_server/statistic/Problem/domain/ProblemSetStatistic.java
@@ -21,16 +21,13 @@ public class ProblemSetStatistic implements StatisticCounter {
     private Long id;
 
     private Long problemSetId;
-    private Long viewCount;
-    private Long submitCount;
 
     @Embedded
     private CountStatistic countStatistic;
 
-    public ProblemSetStatistic(Long problemSetId, Long viewCount, Long submitCount) {
+    public ProblemSetStatistic(Long problemSetId) {
         this.problemSetId = problemSetId;
-        this.viewCount = viewCount;
-        this.submitCount = submitCount;
+        this.countStatistic = new CountStatistic();
     }
 
     @Override
@@ -41,5 +38,13 @@ public class ProblemSetStatistic implements StatisticCounter {
     @Override
     public void addSubmitCount() {
         this.countStatistic.addSubmitCount();
+    }
+
+    public Long getViewCount() {
+        return this.countStatistic.getViewCount();
+    }
+
+    public Long getSubmitCount() {
+        return this.countStatistic.getSubmitCount();
     }
 }

--- a/src/main/java/com/moplus/moplus_server/statistic/Problem/domain/ProblemStatistic.java
+++ b/src/main/java/com/moplus/moplus_server/statistic/Problem/domain/ProblemStatistic.java
@@ -1,6 +1,7 @@
 package com.moplus.moplus_server.statistic.Problem.domain;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -13,7 +14,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ProblemStatistic {
+public class ProblemStatistic implements StatisticCounter {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -24,10 +25,23 @@ public class ProblemStatistic {
     private Long viewCount;
     private Long submitCount;
 
+    @Embedded
+    private CountStatistic countStatistic;
+
     @Builder
     public ProblemStatistic(Long problemId, Long viewCount, Long submitCount) {
         this.problemId = problemId;
         this.viewCount = viewCount;
         this.submitCount = submitCount;
+    }
+
+    @Override
+    public void addViewCount() {
+        this.countStatistic.addViewCount();
+    }
+
+    @Override
+    public void addSubmitCount() {
+        this.countStatistic.addSubmitCount();
     }
 }

--- a/src/main/java/com/moplus/moplus_server/statistic/Problem/domain/ProblemStatistic.java
+++ b/src/main/java/com/moplus/moplus_server/statistic/Problem/domain/ProblemStatistic.java
@@ -22,17 +22,14 @@ public class ProblemStatistic implements StatisticCounter {
     private Long id;
 
     private Long problemId;
-    private Long viewCount;
-    private Long submitCount;
 
     @Embedded
     private CountStatistic countStatistic;
 
     @Builder
-    public ProblemStatistic(Long problemId, Long viewCount, Long submitCount) {
+    public ProblemStatistic(Long problemId) {
         this.problemId = problemId;
-        this.viewCount = viewCount;
-        this.submitCount = submitCount;
+        this.countStatistic = new CountStatistic();
     }
 
     @Override
@@ -43,5 +40,13 @@ public class ProblemStatistic implements StatisticCounter {
     @Override
     public void addSubmitCount() {
         this.countStatistic.addSubmitCount();
+    }
+
+    public Long getViewCount() {
+        return this.countStatistic.getViewCount();
+    }
+
+    public Long getSubmitCount() {
+        return this.countStatistic.getSubmitCount();
     }
 }

--- a/src/main/java/com/moplus/moplus_server/statistic/Problem/domain/ProblemStatistic.java
+++ b/src/main/java/com/moplus/moplus_server/statistic/Problem/domain/ProblemStatistic.java
@@ -1,0 +1,33 @@
+package com.moplus.moplus_server.statistic.Problem.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProblemStatistic {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "problem_statistic_id")
+    private Long id;
+
+    private Long problemId;
+    private Long viewCount;
+    private Long submitCount;
+
+    @Builder
+    public ProblemStatistic(Long problemId, Long viewCount, Long submitCount) {
+        this.problemId = problemId;
+        this.viewCount = viewCount;
+        this.submitCount = submitCount;
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/statistic/Problem/domain/StatisticCounter.java
+++ b/src/main/java/com/moplus/moplus_server/statistic/Problem/domain/StatisticCounter.java
@@ -1,0 +1,11 @@
+package com.moplus.moplus_server.statistic.Problem.domain;
+
+public interface StatisticCounter {
+    void addSubmitCount();
+
+    void addViewCount();
+
+    default void updateCount(StatisticFieldType type) {
+        type.updateCount(this);
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/statistic/Problem/domain/StatisticEntityTarget.java
+++ b/src/main/java/com/moplus/moplus_server/statistic/Problem/domain/StatisticEntityTarget.java
@@ -1,0 +1,5 @@
+package com.moplus.moplus_server.statistic.Problem.domain;
+
+public enum StatisticEntityTarget {
+    PROBLEM, PROBLEM_SET, CHILD_PROBLEM
+}

--- a/src/main/java/com/moplus/moplus_server/statistic/Problem/domain/StatisticFieldType.java
+++ b/src/main/java/com/moplus/moplus_server/statistic/Problem/domain/StatisticFieldType.java
@@ -1,0 +1,16 @@
+package com.moplus.moplus_server.statistic.Problem.domain;
+
+import java.util.function.Consumer;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum StatisticFieldType {
+    VIEW(StatisticCounter::addViewCount),
+    SUBMIT(StatisticCounter::addSubmitCount);
+
+    private final Consumer<StatisticCounter> countUpdater;
+
+    public void updateCount(StatisticCounter counter) {
+        countUpdater.accept(counter);
+    }
+} 

--- a/src/main/java/com/moplus/moplus_server/statistic/Problem/repository/ChildProblemStatisticRepository.java
+++ b/src/main/java/com/moplus/moplus_server/statistic/Problem/repository/ChildProblemStatisticRepository.java
@@ -1,0 +1,13 @@
+package com.moplus.moplus_server.statistic.Problem.repository;
+
+import com.moplus.moplus_server.global.error.exception.ErrorCode;
+import com.moplus.moplus_server.global.error.exception.NotFoundException;
+import com.moplus.moplus_server.statistic.Problem.domain.ChildProblemStatistic;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChildProblemStatisticRepository extends JpaRepository<ChildProblemStatistic, Long> {
+    default ChildProblemStatistic findByIdElseThrow(Long id) {
+        return findById(id)
+            .orElseThrow(() -> new NotFoundException(ErrorCode.CHILD_PROBLEM_STATISTIC_NOT_FOUND));
+    }
+} 

--- a/src/main/java/com/moplus/moplus_server/statistic/Problem/repository/ProblemSetStatisticRepository.java
+++ b/src/main/java/com/moplus/moplus_server/statistic/Problem/repository/ProblemSetStatisticRepository.java
@@ -1,0 +1,13 @@
+package com.moplus.moplus_server.statistic.Problem.repository;
+
+import com.moplus.moplus_server.global.error.exception.ErrorCode;
+import com.moplus.moplus_server.global.error.exception.NotFoundException;
+import com.moplus.moplus_server.statistic.Problem.domain.ProblemSetStatistic;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProblemSetStatisticRepository extends JpaRepository<ProblemSetStatistic, Long> {
+    default ProblemSetStatistic findByIdElseThrow(Long id) {
+        return findById(id)
+            .orElseThrow(() -> new NotFoundException(ErrorCode.PROBLEM_SET_STATISTIC_NOT_FOUND));
+    }
+} 

--- a/src/main/java/com/moplus/moplus_server/statistic/Problem/repository/ProblemStatisticRepository.java
+++ b/src/main/java/com/moplus/moplus_server/statistic/Problem/repository/ProblemStatisticRepository.java
@@ -1,0 +1,13 @@
+package com.moplus.moplus_server.statistic.Problem.repository;
+
+import com.moplus.moplus_server.global.error.exception.ErrorCode;
+import com.moplus.moplus_server.global.error.exception.NotFoundException;
+import com.moplus.moplus_server.statistic.Problem.domain.ProblemStatistic;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProblemStatisticRepository extends JpaRepository<ProblemStatistic, Long> {
+    default ProblemStatistic findByIdElseThrow(Long id) {
+        return findById(id)
+            .orElseThrow(() -> new NotFoundException(ErrorCode.PROBLEM_STATISTIC_NOT_FOUND));
+    }
+} 

--- a/src/main/java/com/moplus/moplus_server/statistic/Problem/service/CountStatisticsUpdateService.java
+++ b/src/main/java/com/moplus/moplus_server/statistic/Problem/service/CountStatisticsUpdateService.java
@@ -1,0 +1,33 @@
+package com.moplus.moplus_server.statistic.Problem.service;
+
+import com.moplus.moplus_server.statistic.Problem.domain.StatisticCounter;
+import com.moplus.moplus_server.statistic.Problem.domain.StatisticEntityTarget;
+import com.moplus.moplus_server.statistic.Problem.domain.StatisticFieldType;
+import com.moplus.moplus_server.statistic.Problem.repository.ChildProblemStatisticRepository;
+import com.moplus.moplus_server.statistic.Problem.repository.ProblemSetStatisticRepository;
+import com.moplus.moplus_server.statistic.Problem.repository.ProblemStatisticRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CountStatisticsUpdateService {
+    private final ProblemStatisticRepository problemStatisticRepository;
+    private final ProblemSetStatisticRepository problemSetStatisticRepository;
+    private final ChildProblemStatisticRepository childProblemStatisticRepository;
+
+    @Transactional
+    public void updateStatistics(Long id, StatisticFieldType type, StatisticEntityTarget target) {
+        StatisticCounter statistic = findStatistic(id, target);
+        statistic.updateCount(type);
+    }
+
+    private StatisticCounter findStatistic(Long id, StatisticEntityTarget target) {
+        return switch (target) {
+            case PROBLEM -> problemStatisticRepository.findByIdElseThrow(id);
+            case PROBLEM_SET -> problemSetStatisticRepository.findByIdElseThrow(id);
+            case CHILD_PROBLEM -> childProblemStatisticRepository.findByIdElseThrow(id);
+        };
+    }
+}

--- a/src/test/java/com/moplus/moplus_server/statistic/Problem/service/CountStatisticsUpdateServiceTest.java
+++ b/src/test/java/com/moplus/moplus_server/statistic/Problem/service/CountStatisticsUpdateServiceTest.java
@@ -1,0 +1,87 @@
+package com.moplus.moplus_server.statistic.Problem.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.moplus.moplus_server.statistic.Problem.domain.ChildProblemStatistic;
+import com.moplus.moplus_server.statistic.Problem.domain.ProblemSetStatistic;
+import com.moplus.moplus_server.statistic.Problem.domain.ProblemStatistic;
+import com.moplus.moplus_server.statistic.Problem.domain.StatisticEntityTarget;
+import com.moplus.moplus_server.statistic.Problem.domain.StatisticFieldType;
+import com.moplus.moplus_server.statistic.Problem.repository.ChildProblemStatisticRepository;
+import com.moplus.moplus_server.statistic.Problem.repository.ProblemSetStatisticRepository;
+import com.moplus.moplus_server.statistic.Problem.repository.ProblemStatisticRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CountStatisticsUpdateServiceTest {
+
+    @InjectMocks
+    private CountStatisticsUpdateService countStatisticsUpdateService;
+
+    @Mock
+    private ProblemStatisticRepository problemStatisticRepository;
+    @Mock
+    private ProblemSetStatisticRepository problemSetStatisticRepository;
+    @Mock
+    private ChildProblemStatisticRepository childProblemStatisticRepository;
+
+    @Test
+    void 문항_조회수_증가() {
+        // given
+        Long problemId = 1L;
+        ProblemStatistic problemStatistic = new ProblemStatistic(problemId);
+        given(problemStatisticRepository.findByIdElseThrow(problemId))
+                .willReturn(problemStatistic);
+
+        // when
+        countStatisticsUpdateService.updateStatistics(problemId, StatisticFieldType.VIEW,
+                StatisticEntityTarget.PROBLEM);
+
+        // then
+        verify(problemStatisticRepository).findByIdElseThrow(problemId);
+        assertThat(problemStatistic.getViewCount()).isEqualTo(1L);
+        assertThat(problemStatistic.getSubmitCount()).isEqualTo(0L);
+    }
+
+    @Test
+    void 문항세트_풀이수_증가() {
+        // given
+        Long problemSetId = 1L;
+        ProblemSetStatistic problemSetStatistic = new ProblemSetStatistic(problemSetId);
+        given(problemSetStatisticRepository.findByIdElseThrow(problemSetId))
+                .willReturn(problemSetStatistic);
+
+        // when
+        countStatisticsUpdateService.updateStatistics(problemSetId, StatisticFieldType.SUBMIT,
+                StatisticEntityTarget.PROBLEM_SET);
+
+        // then
+        verify(problemSetStatisticRepository).findByIdElseThrow(problemSetId);
+        assertThat(problemSetStatistic.getSubmitCount()).isEqualTo(1L);
+        assertThat(problemSetStatistic.getViewCount()).isEqualTo(0L);
+    }
+
+    @Test
+    void 새끼문항_조회수_증가() {
+        // given
+        Long childProblemId = 1L;
+        ChildProblemStatistic childProblemStatistic = new ChildProblemStatistic(childProblemId);
+        given(childProblemStatisticRepository.findByIdElseThrow(childProblemId))
+                .willReturn(childProblemStatistic);
+
+        // when
+        countStatisticsUpdateService.updateStatistics(childProblemId, StatisticFieldType.VIEW,
+                StatisticEntityTarget.CHILD_PROBLEM);
+
+        // then
+        verify(childProblemStatisticRepository).findByIdElseThrow(childProblemId);
+        assertThat(childProblemStatistic.getViewCount()).isEqualTo(1L);
+        assertThat(childProblemStatistic.getSubmitCount()).isEqualTo(0L);
+    }
+} 


### PR DESCRIPTION
# 💡 Issue
- resolved: #92 

# 📸 Screenshot
<!-- 필요 시 사진, 동영상 등을 첨부해 주세요
ex) 포스트맨, 스웨거, 로그 등 -->
![image](https://github.com/user-attachments/assets/419b260a-2d18-4f58-95cf-5c466453c9aa)


# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->
- 문항, 새끼문항, 세트에 대한 조회수, 풀이수 통계를 위한 도메인 설계를 진행하였습니다.
## 고민사항
- 각 도메인에 대해서 조회수, 풀이수를 업데이트를 하는 행위는 모두 같았습니다.
- 업데이트를 해야하는 필드도 같았고 수행하는 로직의 규칙도 같았습니다.
- 공통 로직임에도 불구하고 각 통계 도메인별로 똑같은 행위를 하는 서비스 구현체가 각각 생기는 것은 유지보수 측면에서 좋아보이지 않았습니다.
    - 예시) ProblemStatisticUpdateService, ChildProblemStatisticUpdateService, ProblemSetStatisticUpdateService
- 하나의 서비스에서 여러 instance 종류에 상관없이 공통 로직을 수행시키기 위해 아래와 같은 2가지 구조를 고민했습니다.
### 1. 상속 
![image](https://github.com/user-attachments/assets/6d7ea4d4-b924-4d99-ae2c-e949e5fbe70f)
- 다형성을 구현하기 위해 상속을 고려했으나, DB의 테이블 구조가 상속을 지원하지 않고 이를 하나의 테이블로 구현하거나 공통 부분과 하위 부분을 두 개로 나누어 type을 통해 연결하는 방식이 있었습니다.
- 하지만 이러한 방식은 확장성에 제약이 있을 것 같았고, 조회수와 풀이수 같은 공통적인 통계가 문항, 새끼문항, 세트 등 다양한 도메인의 내용이 통계라는 한 공통 상위 테이블에 섞여 저장되면 조회 성능에도 문제가 될 수 있었습니다.

### 2. 합성 (최종 선택)
![image](https://github.com/user-attachments/assets/31f5ac64-24a4-49c0-92fa-1d4250f7a3d4)

- 각 도메인이 CountStatistic를 내부로 가지고 있는 합성을 선택하고 StatisticCounter 인터페이스를 구현하게하여 다형성을 구현했습니다.
- 통계 서비스는 PROBLEM, PROBLEM_SET, CHILD_PROBLEM으로 엔티티를 구분하고
- VIEW, SUBMIT으로 필드를 구분하여 업데이트합니다.
 
# 💬 To Reviewers
<!-- 리뷰어들에게 남기고 싶은 말을 적어주세요
ex) 코드 리뷰 간 참고사항, 질문 등 -->
- 이벤트 발행은 추후 구현하겠습니다.

# 🔗 Reference
<!-- 이슈를 해결하며 도움이 되었거나, 참고했던 아티클들의 링크를 첨부해 주세요 -->
- 합성 개념 참고 : https://inpa.tistory.com/entry/OOP-%F0%9F%92%A0-%EA%B0%9D%EC%B2%B4-%EC%A7%80%ED%96%A5%EC%9D%98-%EC%83%81%EC%86%8D-%EB%AC%B8%EC%A0%9C%EC%A0%90%EA%B3%BC-%ED%95%A9%EC%84%B1Composition-%EC%9D%B4%ED%95%B4%ED%95%98%EA%B8%B0
