### PR TITLE
Feature/#94 사용자 제출 관련 api 구현

### DIFF
--- a/src/main/java/com/moplus/moplus_server/client/submit/controller/ClientGetController.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/controller/ClientGetController.java
@@ -2,6 +2,7 @@ package com.moplus.moplus_server.client.submit.controller;
 
 import com.moplus.moplus_server.client.submit.dto.response.AllProblemGetResponse;
 import com.moplus.moplus_server.client.submit.dto.response.CommentaryGetResponse;
+import com.moplus.moplus_server.client.submit.dto.response.ProblemClientGetResponse;
 import com.moplus.moplus_server.client.submit.service.ClientGetService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -38,5 +39,14 @@ public class ClientGetController {
             @PathVariable int month
     ) {
         return ResponseEntity.ok(clientGetService.getAllProblem(year, month));
+    }
+
+    @GetMapping("problem/{publishId}/{problemId}")
+    @Operation(summary = "문항 조회", description = "사용자에게 보여지는 문항을 조회합니다.")
+    public ResponseEntity<ProblemClientGetResponse> getProblem(
+            @PathVariable Long publishId,
+            @PathVariable Long problemId
+    ) {
+        return ResponseEntity.ok(clientGetService.getProblem(publishId, problemId));
     }
 }

--- a/src/main/java/com/moplus/moplus_server/client/submit/controller/ClientGetController.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/controller/ClientGetController.java
@@ -1,6 +1,7 @@
 package com.moplus.moplus_server.client.submit.controller;
 
 import com.moplus.moplus_server.client.submit.dto.response.AllProblemGetResponse;
+import com.moplus.moplus_server.client.submit.dto.response.CommentaryGetResponse;
 import com.moplus.moplus_server.client.submit.service.ClientGetService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -10,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "클라이언트 조회", description = "클라이언트 조회 관련 API")
@@ -19,6 +21,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class ClientGetController {
 
     private final ClientGetService clientGetService;
+
+    @GetMapping("commentary")
+    @Operation(summary = "해설 조회", description = "문항 별 해설/처방을 조회합니다.")
+    public ResponseEntity<CommentaryGetResponse> getCommentary(
+            @RequestParam(value = "publishId", required = false) Long publishId,
+            @RequestParam(value = "problemId", required = false) Long problemId
+    ) {
+        return ResponseEntity.ok(clientGetService.getCommentary(publishId, problemId));
+    }
 
     @GetMapping("allProblem/{year}/{month}")
     @Operation(summary = "전체 문제 조회", description = "월별 문제들에 대한 진행도와 정보들을 조회합니다.")

--- a/src/main/java/com/moplus/moplus_server/client/submit/controller/ClientGetController.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/controller/ClientGetController.java
@@ -1,0 +1,31 @@
+package com.moplus.moplus_server.client.submit.controller;
+
+import com.moplus.moplus_server.client.submit.dto.response.AllProblemGetResponse;
+import com.moplus.moplus_server.client.submit.service.ClientGetService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "클라이언트 조회", description = "클라이언트 조회 관련 API")
+@RestController
+@RequestMapping("/api/v1/client")
+@RequiredArgsConstructor
+public class ClientGetController {
+
+    private final ClientGetService clientGetService;
+
+    @GetMapping("allProblem/{year}/{month}")
+    @Operation(summary = "전체 문제 조회", description = "월별 문제들에 대한 진행도와 정보들을 조회합니다.")
+    public ResponseEntity<List<AllProblemGetResponse>> getAllProblem(
+            @PathVariable int year,
+            @PathVariable int month
+    ) {
+        return ResponseEntity.ok(clientGetService.getAllProblem(year, month));
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/client/submit/controller/ClientGetController.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/controller/ClientGetController.java
@@ -1,6 +1,7 @@
 package com.moplus.moplus_server.client.submit.controller;
 
 import com.moplus.moplus_server.client.submit.dto.response.AllProblemGetResponse;
+import com.moplus.moplus_server.client.submit.dto.response.ChildProblemClientGetResponse;
 import com.moplus.moplus_server.client.submit.dto.response.CommentaryGetResponse;
 import com.moplus.moplus_server.client.submit.dto.response.ProblemClientGetResponse;
 import com.moplus.moplus_server.client.submit.service.ClientGetService;
@@ -48,5 +49,15 @@ public class ClientGetController {
             @PathVariable Long problemId
     ) {
         return ResponseEntity.ok(clientGetService.getProblem(publishId, problemId));
+    }
+
+    @GetMapping("problem/{publishId}/{problemId}/{childProblemId}")
+    @Operation(summary = "새끼문항 조회", description = "사용자에게 보여지는 새끼문항을 조회합니다.")
+    public ResponseEntity<ChildProblemClientGetResponse> getChildProblem(
+            @PathVariable Long publishId,
+            @PathVariable Long problemId,
+            @PathVariable Long childProblemId
+    ) {
+        return ResponseEntity.ok(clientGetService.getChildProblem(publishId, problemId, childProblemId));
     }
 }

--- a/src/main/java/com/moplus/moplus_server/client/submit/controller/ClientSubmitController.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/controller/ClientSubmitController.java
@@ -1,7 +1,9 @@
 package com.moplus.moplus_server.client.submit.controller;
 
+import com.moplus.moplus_server.client.submit.domain.ChildProblemSubmitStatus;
 import com.moplus.moplus_server.client.submit.domain.ProblemSubmitStatus;
 import com.moplus.moplus_server.client.submit.dto.request.ChildProblemSubmitCreateRequest;
+import com.moplus.moplus_server.client.submit.dto.request.ChildProblemSubmitUpdateRequest;
 import com.moplus.moplus_server.client.submit.dto.request.ProblemSubmitCreateRequest;
 import com.moplus.moplus_server.client.submit.dto.request.ProblemSubmitUpdateRequest;
 import com.moplus.moplus_server.client.submit.service.ClientSubmitService;
@@ -47,5 +49,13 @@ public class ClientSubmitController {
     ) {
         clientSubmitService.createChildProblemSubmit(request);
         return ResponseEntity.ok(null);
+    }
+
+    @PutMapping("childProblemSubmit")
+    @Operation(summary = "새끼문항 제출 업데이트", description = "제출한 답안을 바탕으로 문항 제출의 상태를 업데이트합니다.")
+    public ResponseEntity<ChildProblemSubmitStatus> updateChildProblemSubmit(
+            @RequestBody ChildProblemSubmitUpdateRequest request
+    ) {
+        return ResponseEntity.ok(clientSubmitService.updateChildProblemSubmit(request));
     }
 }

--- a/src/main/java/com/moplus/moplus_server/client/submit/controller/ClientSubmitController.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/controller/ClientSubmitController.java
@@ -3,6 +3,7 @@ package com.moplus.moplus_server.client.submit.controller;
 import com.moplus.moplus_server.client.submit.domain.ChildProblemSubmitStatus;
 import com.moplus.moplus_server.client.submit.domain.ProblemSubmitStatus;
 import com.moplus.moplus_server.client.submit.dto.request.ChildProblemSubmitCreateRequest;
+import com.moplus.moplus_server.client.submit.dto.request.ChildProblemSubmitUpdateIncorrectRequest;
 import com.moplus.moplus_server.client.submit.dto.request.ChildProblemSubmitUpdateRequest;
 import com.moplus.moplus_server.client.submit.dto.request.ProblemSubmitCreateRequest;
 import com.moplus.moplus_server.client.submit.dto.request.ProblemSubmitUpdateRequest;
@@ -57,5 +58,14 @@ public class ClientSubmitController {
             @RequestBody ChildProblemSubmitUpdateRequest request
     ) {
         return ResponseEntity.ok(clientSubmitService.updateChildProblemSubmit(request));
+    }
+
+    @PutMapping("childProblemSubmit/incorrect")
+    @Operation(summary = "새끼문항 제출 틀림 업데이트", description = "새끼문항 제출의 상태를 틀림으로 업데이트합니다.")
+    public ResponseEntity<Void> updateChildProblemSubmitIncorrect(
+            @RequestBody ChildProblemSubmitUpdateIncorrectRequest request
+    ) {
+        clientSubmitService.updateChildProblemSubmitIncorrect(request);
+        return ResponseEntity.ok(null);
     }
 }

--- a/src/main/java/com/moplus/moplus_server/client/submit/controller/ClientSubmitController.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/controller/ClientSubmitController.java
@@ -1,0 +1,30 @@
+package com.moplus.moplus_server.client.submit.controller;
+
+import com.moplus.moplus_server.client.submit.dto.request.ProblemSubmitCreateRequest;
+import com.moplus.moplus_server.client.submit.service.ClientSubmitService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "클라이언트 제출", description = "클라이언트 제출 관련 API")
+@RestController
+@RequestMapping("/api/v1/client")
+@RequiredArgsConstructor
+public class ClientSubmitController {
+
+    private final ClientSubmitService clientSubmitService;
+
+    @PostMapping("problemSubmit")
+    @Operation(summary = "문항 제출 데이터 생성", description = "문항 제출을 '진행중'으로 생성합니다.")
+    public ResponseEntity<Void> createProblemSubmit(
+            @RequestBody ProblemSubmitCreateRequest request
+            ) {
+        clientSubmitService.createProblemSubmit(request);
+        return ResponseEntity.ok(null);
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/client/submit/controller/ClientSubmitController.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/controller/ClientSubmitController.java
@@ -1,5 +1,6 @@
 package com.moplus.moplus_server.client.submit.controller;
 
+import com.moplus.moplus_server.client.submit.dto.request.ChildProblemSubmitCreateRequest;
 import com.moplus.moplus_server.client.submit.dto.request.ProblemSubmitCreateRequest;
 import com.moplus.moplus_server.client.submit.service.ClientSubmitService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -20,11 +21,20 @@ public class ClientSubmitController {
     private final ClientSubmitService clientSubmitService;
 
     @PostMapping("problemSubmit")
-    @Operation(summary = "문항 제출 데이터 생성", description = "문항 제출을 '진행중'으로 생성합니다.")
+    @Operation(summary = "문항 제출 생성", description = "문항 제출을 '진행중'으로 생성합니다.")
     public ResponseEntity<Void> createProblemSubmit(
             @RequestBody ProblemSubmitCreateRequest request
             ) {
         clientSubmitService.createProblemSubmit(request);
+        return ResponseEntity.ok(null);
+    }
+
+    @PostMapping("childProblemSubmit")
+    @Operation(summary = "새끼문항 제출 생성", description = "문항에 속한 새끼문항들을 '시작전'으로 생성합니다.")
+    public ResponseEntity<Void> createProblemSubmit(
+            @RequestBody ChildProblemSubmitCreateRequest request
+    ) {
+        clientSubmitService.createChildProblemSubmit(request);
         return ResponseEntity.ok(null);
     }
 }

--- a/src/main/java/com/moplus/moplus_server/client/submit/controller/ClientSubmitController.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/controller/ClientSubmitController.java
@@ -1,13 +1,16 @@
 package com.moplus.moplus_server.client.submit.controller;
 
+import com.moplus.moplus_server.client.submit.domain.ProblemSubmitStatus;
 import com.moplus.moplus_server.client.submit.dto.request.ChildProblemSubmitCreateRequest;
 import com.moplus.moplus_server.client.submit.dto.request.ProblemSubmitCreateRequest;
+import com.moplus.moplus_server.client.submit.dto.request.ProblemSubmitUpdateRequest;
 import com.moplus.moplus_server.client.submit.service.ClientSubmitService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,6 +30,14 @@ public class ClientSubmitController {
             ) {
         clientSubmitService.createProblemSubmit(request);
         return ResponseEntity.ok(null);
+    }
+
+    @PutMapping("problemSubmit")
+    @Operation(summary = "문항 제출 업데이트", description = "제출한 답안을 바탕으로 문항 제출의 상태를 업데이트합니다.")
+    public ResponseEntity<ProblemSubmitStatus> updateProblemSubmit(
+            @RequestBody ProblemSubmitUpdateRequest request
+    ) {
+        return ResponseEntity.ok(clientSubmitService.updateProblemSubmit(request));
     }
 
     @PostMapping("childProblemSubmit")

--- a/src/main/java/com/moplus/moplus_server/client/submit/controller/CommentaryGetController.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/controller/CommentaryGetController.java
@@ -1,0 +1,30 @@
+package com.moplus.moplus_server.client.submit.controller;
+
+import com.moplus.moplus_server.client.submit.dto.response.CommentaryGetResponse;
+import com.moplus.moplus_server.client.submit.service.CommentaryGetService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "클라이언트 해설 조회", description = "클라이언트 해설 조회 관련 API")
+@RestController
+@RequestMapping("/api/v1/client")
+@RequiredArgsConstructor
+public class CommentaryGetController {
+
+    private final CommentaryGetService commentaryGetService;
+
+    @GetMapping("commentary")
+    @Operation(summary = "해설 조회", description = "문항 별 해설/처방을 조회합니다.")
+    public ResponseEntity<CommentaryGetResponse> getCommentary(
+            @RequestParam(value = "publishId", required = false) Long publishId,
+            @RequestParam(value = "problemId", required = false) Long problemId
+    ) {
+        return ResponseEntity.ok(commentaryGetService.getCommentary(publishId, problemId));
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/client/submit/controller/ProblemGetController.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/controller/ProblemGetController.java
@@ -2,9 +2,8 @@ package com.moplus.moplus_server.client.submit.controller;
 
 import com.moplus.moplus_server.client.submit.dto.response.AllProblemGetResponse;
 import com.moplus.moplus_server.client.submit.dto.response.ChildProblemClientGetResponse;
-import com.moplus.moplus_server.client.submit.dto.response.CommentaryGetResponse;
 import com.moplus.moplus_server.client.submit.dto.response.ProblemClientGetResponse;
-import com.moplus.moplus_server.client.submit.service.ClientGetService;
+import com.moplus.moplus_server.client.submit.service.ProblemsGetService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -13,33 +12,23 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "클라이언트 조회", description = "클라이언트 조회 관련 API")
+@Tag(name = "클라이언트 문제 조회", description = "클라이언트 문제 조회 관련 API")
 @RestController
 @RequestMapping("/api/v1/client")
 @RequiredArgsConstructor
-public class ClientGetController {
+public class ProblemGetController {
 
-    private final ClientGetService clientGetService;
+    private final ProblemsGetService problemsGetService;
 
-    @GetMapping("commentary")
-    @Operation(summary = "해설 조회", description = "문항 별 해설/처방을 조회합니다.")
-    public ResponseEntity<CommentaryGetResponse> getCommentary(
-            @RequestParam(value = "publishId", required = false) Long publishId,
-            @RequestParam(value = "problemId", required = false) Long problemId
-    ) {
-        return ResponseEntity.ok(clientGetService.getCommentary(publishId, problemId));
-    }
-
-    @GetMapping("allProblem/{year}/{month}")
+    @GetMapping("problem/all/{year}/{month}")
     @Operation(summary = "전체 문제 조회", description = "월별 문제들에 대한 진행도와 정보들을 조회합니다.")
     public ResponseEntity<List<AllProblemGetResponse>> getAllProblem(
             @PathVariable int year,
             @PathVariable int month
     ) {
-        return ResponseEntity.ok(clientGetService.getAllProblem(year, month));
+        return ResponseEntity.ok(problemsGetService.getAllProblem(year, month));
     }
 
     @GetMapping("problem/{publishId}/{problemId}")
@@ -48,7 +37,7 @@ public class ClientGetController {
             @PathVariable Long publishId,
             @PathVariable Long problemId
     ) {
-        return ResponseEntity.ok(clientGetService.getProblem(publishId, problemId));
+        return ResponseEntity.ok(problemsGetService.getProblem(publishId, problemId));
     }
 
     @GetMapping("problem/{publishId}/{problemId}/{childProblemId}")
@@ -58,6 +47,6 @@ public class ClientGetController {
             @PathVariable Long problemId,
             @PathVariable Long childProblemId
     ) {
-        return ResponseEntity.ok(clientGetService.getChildProblem(publishId, problemId, childProblemId));
+        return ResponseEntity.ok(problemsGetService.getChildProblem(publishId, problemId, childProblemId));
     }
 }

--- a/src/main/java/com/moplus/moplus_server/client/submit/domain/ChildProblemSubmit.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/domain/ChildProblemSubmit.java
@@ -37,4 +37,8 @@ public class ChildProblemSubmit extends BaseEntity {
         this.childProblemId = childProblemId;
         this.status = status;
     }
+
+    public void updateStatus(ChildProblemSubmitStatus status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/com/moplus/moplus_server/client/submit/domain/ChildProblemSubmit.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/domain/ChildProblemSubmit.java
@@ -41,4 +41,9 @@ public class ChildProblemSubmit extends BaseEntity {
     public void updateStatus(ChildProblemSubmitStatus status) {
         this.status = status;
     }
+
+    public void updateStatusIncorrect() {
+        this.status = ChildProblemSubmitStatus.INCORRECT;
+
+    }
 }

--- a/src/main/java/com/moplus/moplus_server/client/submit/domain/ChildProblemSubmitStatus.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/domain/ChildProblemSubmitStatus.java
@@ -8,14 +8,11 @@ public enum ChildProblemSubmitStatus {
     public static ChildProblemSubmitStatus determineStatus(ChildProblemSubmitStatus currentStatus, String memberAnswer, String childProblemAnswer) {
         boolean isCorrect = childProblemAnswer.trim().equals(memberAnswer.trim());
 
-        if (currentStatus == CORRECT) {
-            return isCorrect ? CORRECT : INCORRECT;
-        } else if (currentStatus == INCORRECT) {
-            return isCorrect ? RETRY_CORRECT : INCORRECT;
-        } else if (currentStatus == RETRY_CORRECT) {
-            return isCorrect ? RETRY_CORRECT : INCORRECT;
-        } else {
-            return isCorrect ? CORRECT : INCORRECT;
-        }
+        return switch (currentStatus) {
+            case CORRECT -> isCorrect ? CORRECT : INCORRECT;
+            case INCORRECT -> isCorrect ? RETRY_CORRECT : INCORRECT;
+            case RETRY_CORRECT -> isCorrect ? RETRY_CORRECT : INCORRECT;
+            default -> isCorrect ? CORRECT : INCORRECT;
+        };
     }
 }

--- a/src/main/java/com/moplus/moplus_server/client/submit/domain/ChildProblemSubmitStatus.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/domain/ChildProblemSubmitStatus.java
@@ -4,5 +4,18 @@ public enum ChildProblemSubmitStatus {
     CORRECT,
     INCORRECT,
     RETRY_CORRECT,
-    NOT_STARTED
+    NOT_STARTED;
+    public static ChildProblemSubmitStatus determineStatus(ChildProblemSubmitStatus currentStatus, String memberAnswer, String childProblemAnswer) {
+        boolean isCorrect = childProblemAnswer.trim().equals(memberAnswer.trim());
+
+        if (currentStatus == CORRECT) {
+            return isCorrect ? CORRECT : INCORRECT;
+        } else if (currentStatus == INCORRECT) {
+            return isCorrect ? RETRY_CORRECT : INCORRECT;
+        } else if (currentStatus == RETRY_CORRECT) {
+            return isCorrect ? RETRY_CORRECT : INCORRECT;
+        } else {
+            return isCorrect ? CORRECT : INCORRECT;
+        }
+    }
 }

--- a/src/main/java/com/moplus/moplus_server/client/submit/domain/ChildProblemSubmitStatus.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/domain/ChildProblemSubmitStatus.java
@@ -3,5 +3,6 @@ package com.moplus.moplus_server.client.submit.domain;
 public enum ChildProblemSubmitStatus {
     CORRECT,
     INCORRECT,
-    RETRY_CORRECT
+    RETRY_CORRECT,
+    NOT_STARTED
 }

--- a/src/main/java/com/moplus/moplus_server/client/submit/domain/ProblemSubmit.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/domain/ProblemSubmit.java
@@ -37,4 +37,8 @@ public class ProblemSubmit extends BaseEntity {
         this.problemId = problemId;
         this.status = status;
     }
+
+    public void updateStatus(ProblemSubmitStatus status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/com/moplus/moplus_server/client/submit/domain/ProblemSubmitStatus.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/domain/ProblemSubmitStatus.java
@@ -8,14 +8,11 @@ public enum ProblemSubmitStatus {
     public static ProblemSubmitStatus determineStatus(ProblemSubmitStatus currentStatus, String memberAnswer, String problemAnswer) {
         boolean isCorrect = problemAnswer.trim().equals(memberAnswer.trim());
 
-        if (currentStatus == CORRECT) {
-            return isCorrect ? CORRECT : INCORRECT;
-        } else if (currentStatus == INCORRECT) {
-            return isCorrect ? RETRY_CORRECT : INCORRECT;
-        } else if (currentStatus == IN_PROGRESS) {
-            return isCorrect ? CORRECT : INCORRECT;
-        } else {
-            return isCorrect ? RETRY_CORRECT : INCORRECT;
-        }
+        return switch (currentStatus) {
+            case CORRECT -> isCorrect ? CORRECT : INCORRECT;
+            case INCORRECT -> isCorrect ? RETRY_CORRECT : INCORRECT;
+            case IN_PROGRESS -> isCorrect ? CORRECT : INCORRECT;
+            default -> isCorrect ? RETRY_CORRECT : INCORRECT;
+        };
     }
 }

--- a/src/main/java/com/moplus/moplus_server/client/submit/domain/ProblemSubmitStatus.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/domain/ProblemSubmitStatus.java
@@ -4,5 +4,18 @@ public enum ProblemSubmitStatus {
     CORRECT,
     INCORRECT,
     IN_PROGRESS,
-    RETRY_CORRECT
+    RETRY_CORRECT;
+    public static ProblemSubmitStatus determineStatus(ProblemSubmitStatus currentStatus, String memberAnswer, String problemAnswer) {
+        boolean isCorrect = problemAnswer.trim().equals(memberAnswer.trim());
+
+        if (currentStatus == CORRECT) {
+            return isCorrect ? CORRECT : INCORRECT;
+        } else if (currentStatus == INCORRECT) {
+            return isCorrect ? RETRY_CORRECT : INCORRECT;
+        } else if (currentStatus == IN_PROGRESS) {
+            return isCorrect ? CORRECT : INCORRECT;
+        } else {
+            return isCorrect ? RETRY_CORRECT : INCORRECT;
+        }
+    }
 }

--- a/src/main/java/com/moplus/moplus_server/client/submit/dto/request/ChildProblemSubmitCreateRequest.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/dto/request/ChildProblemSubmitCreateRequest.java
@@ -1,0 +1,7 @@
+package com.moplus.moplus_server.client.submit.dto.request;
+
+public record ChildProblemSubmitCreateRequest(
+        Long publishId,
+        Long problemId
+) {
+}

--- a/src/main/java/com/moplus/moplus_server/client/submit/dto/request/ChildProblemSubmitUpdateIncorrectRequest.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/dto/request/ChildProblemSubmitUpdateIncorrectRequest.java
@@ -1,0 +1,11 @@
+package com.moplus.moplus_server.client.submit.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record ChildProblemSubmitUpdateIncorrectRequest(
+        @NotNull(message = "발행 ID는 필수입니다.")
+        Long publishId,
+        @NotNull(message = "새끼문항 ID는 필수입니다.")
+        Long childProblemId
+) {
+}

--- a/src/main/java/com/moplus/moplus_server/client/submit/dto/request/ChildProblemSubmitUpdateRequest.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/dto/request/ChildProblemSubmitUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.moplus.moplus_server.client.submit.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record ChildProblemSubmitUpdateRequest(
+        @NotNull(message = "발행 ID는 필수입니다.")
+        Long publishId,
+        @NotNull(message = "새끼문항 ID는 필수입니다.")
+        Long childProblemId,
+        String answer
+) {
+}

--- a/src/main/java/com/moplus/moplus_server/client/submit/dto/request/ProblemSubmitCreateRequest.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/dto/request/ProblemSubmitCreateRequest.java
@@ -1,0 +1,21 @@
+package com.moplus.moplus_server.client.submit.dto.request;
+
+import com.moplus.moplus_server.client.submit.domain.ProblemSubmit;
+import com.moplus.moplus_server.client.submit.domain.ProblemSubmitStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record ProblemSubmitCreateRequest (
+        @NotNull(message = "발행 ID는 필수입니다.")
+        Long publishId,
+        @NotNull(message = "문항 ID는 필수입니다.")
+        Long problemId
+){
+        public ProblemSubmit toEntity(Long memberId) {
+                return ProblemSubmit.builder()
+                        .memberId(memberId)
+                        .publishId(this.publishId)
+                        .problemId(this.problemId)
+                        .status(ProblemSubmitStatus.IN_PROGRESS)
+                        .build();
+        }
+}

--- a/src/main/java/com/moplus/moplus_server/client/submit/dto/request/ProblemSubmitUpdateRequest.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/dto/request/ProblemSubmitUpdateRequest.java
@@ -2,10 +2,11 @@ package com.moplus.moplus_server.client.submit.dto.request;
 
 import jakarta.validation.constraints.NotNull;
 
-public record ChildProblemSubmitCreateRequest(
+public record ProblemSubmitUpdateRequest(
         @NotNull(message = "발행 ID는 필수입니다.")
         Long publishId,
         @NotNull(message = "문항 ID는 필수입니다.")
-        Long problemId
+        Long problemId,
+        String answer
 ) {
 }

--- a/src/main/java/com/moplus/moplus_server/client/submit/dto/response/AllProblemGetResponse.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/dto/response/AllProblemGetResponse.java
@@ -1,0 +1,26 @@
+package com.moplus.moplus_server.client.submit.dto.response;
+
+import com.moplus.moplus_server.client.submit.domain.ProblemSubmitStatus;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record AllProblemGetResponse(
+        Long publishId,
+        LocalDate date,
+        DayProgress progress,
+        List<ProblemSubmitStatus> problemStatuses,
+        String mainProblemImageUrl
+) {
+    public static AllProblemGetResponse of(Long publishId, LocalDate date, DayProgress progress,
+                                           List<ProblemSubmitStatus> problemStatuses, String mainProblemImageUrl) {
+        return AllProblemGetResponse.builder()
+                .publishId(publishId)
+                .date(date)
+                .progress(progress)
+                .problemStatuses(problemStatuses)
+                .mainProblemImageUrl(mainProblemImageUrl)
+                .build();
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/client/submit/dto/response/ChildProblemClientGetResponse.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/dto/response/ChildProblemClientGetResponse.java
@@ -1,0 +1,23 @@
+package com.moplus.moplus_server.client.submit.dto.response;
+
+import com.moplus.moplus_server.client.submit.domain.ChildProblemSubmitStatus;
+import lombok.Builder;
+
+@Builder
+public record ChildProblemClientGetResponse(
+        int problemNumber,
+        int childProblemNumber,
+        String imageUrl,
+        ChildProblemSubmitStatus status
+) {
+    public static ChildProblemClientGetResponse of(int problemNumber, int childProblemNumber, String imageUrl,
+                                                   ChildProblemSubmitStatus status
+    ) {
+        return ChildProblemClientGetResponse.builder()
+                .problemNumber(problemNumber)
+                .childProblemNumber(childProblemNumber)
+                .imageUrl(imageUrl)
+                .status(status)
+                .build();
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/client/submit/dto/response/ChildProblemDetailResponse.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/dto/response/ChildProblemDetailResponse.java
@@ -1,0 +1,20 @@
+package com.moplus.moplus_server.client.submit.dto.response;
+
+import com.moplus.moplus_server.client.submit.domain.ChildProblemSubmitStatus;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record ChildProblemDetailResponse(
+        String imageUrl,
+        List<String> prescriptionImageUrls,
+        ChildProblemSubmitStatus submitStatus
+) {
+    public static ChildProblemDetailResponse of(String imageUrl, List<String> prescriptionImageUrls, ChildProblemSubmitStatus submitStatus) {
+        return ChildProblemDetailResponse.builder()
+                .imageUrl(imageUrl)
+                .prescriptionImageUrls(prescriptionImageUrls)
+                .submitStatus(submitStatus)
+                .build();
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/client/submit/dto/response/CommentaryGetResponse.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/dto/response/CommentaryGetResponse.java
@@ -1,5 +1,6 @@
 package com.moplus.moplus_server.client.submit.dto.response;
 
+import com.moplus.moplus_server.domain.problem.domain.problem.Problem;
 import lombok.Builder;
 
 @Builder
@@ -12,16 +13,14 @@ public record CommentaryGetResponse(
         String seniorTipImageUrl,
         PrescriptionResponse prescription
 ) {
-    public static CommentaryGetResponse of(int problemNumber, String answer, String mainAnalysisImageUrl,
-                                           String mainHandwritingExplanationImageUrl, String readingTipImageUrl,
-                                           String seniorTipImageUrl, PrescriptionResponse prescription) {
+    public static CommentaryGetResponse of(int problemNumber, Problem problem, PrescriptionResponse prescription) {
         return CommentaryGetResponse.builder()
                 .problemNumber(problemNumber)
-                .answer(answer)
-                .mainAnalysisImageUrl(mainAnalysisImageUrl)
-                .mainHandwritingExplanationImageUrl(mainHandwritingExplanationImageUrl)
-                .readingTipImageUrl(readingTipImageUrl)
-                .seniorTipImageUrl(seniorTipImageUrl)
+                .answer(problem.getAnswer())
+                .mainAnalysisImageUrl(problem.getMainAnalysisImageUrl())
+                .mainHandwritingExplanationImageUrl(problem.getMainHandwritingExplanationImageUrl())
+                .readingTipImageUrl(problem.getReadingTipImageUrl())
+                .seniorTipImageUrl(problem.getSeniorTipImageUrl())
                 .prescription(prescription)
                 .build();
     }

--- a/src/main/java/com/moplus/moplus_server/client/submit/dto/response/CommentaryGetResponse.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/dto/response/CommentaryGetResponse.java
@@ -1,0 +1,28 @@
+package com.moplus.moplus_server.client.submit.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record CommentaryGetResponse(
+        int problemNumber,
+        String answer,
+        String mainAnalysisImageUrl,
+        String mainHandwritingExplanationImageUrl,
+        String readingTipImageUrl,
+        String seniorTipImageUrl,
+        PrescriptionResponse prescription
+) {
+    public static CommentaryGetResponse of(int problemNumber, String answer, String mainAnalysisImageUrl,
+                                           String mainHandwritingExplanationImageUrl, String readingTipImageUrl,
+                                           String seniorTipImageUrl, PrescriptionResponse prescription) {
+        return CommentaryGetResponse.builder()
+                .problemNumber(problemNumber)
+                .answer(answer)
+                .mainAnalysisImageUrl(mainAnalysisImageUrl)
+                .mainHandwritingExplanationImageUrl(mainHandwritingExplanationImageUrl)
+                .readingTipImageUrl(readingTipImageUrl)
+                .seniorTipImageUrl(seniorTipImageUrl)
+                .prescription(prescription)
+                .build();
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/client/submit/dto/response/DayProgress.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/dto/response/DayProgress.java
@@ -1,0 +1,21 @@
+package com.moplus.moplus_server.client.submit.dto.response;
+
+import com.moplus.moplus_server.client.submit.domain.ProblemSubmitStatus;
+import java.util.List;
+
+public enum DayProgress {
+    COMPLETE,
+    INCOMPLETE,
+    IN_PROGRESS;
+    public static DayProgress determineDayProgress(List<ProblemSubmitStatus> problemStatuses) {
+        if (problemStatuses.isEmpty()) {
+            return INCOMPLETE;
+        }
+        else if (problemStatuses.contains(ProblemSubmitStatus.IN_PROGRESS)) {
+            return IN_PROGRESS;
+        }
+        else{
+            return COMPLETE;
+        }
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/client/submit/dto/response/PrescriptionResponse.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/dto/response/PrescriptionResponse.java
@@ -1,0 +1,18 @@
+package com.moplus.moplus_server.client.submit.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record PrescriptionResponse(
+    List<ChildProblemDetailResponse> childProblem,
+    ProblemDetailResponse mainProblem
+) {
+    public static PrescriptionResponse of(List<ChildProblemDetailResponse> childProblem,
+                                          ProblemDetailResponse mainProblem) {
+        return PrescriptionResponse.builder()
+                .childProblem(childProblem)
+                .mainProblem(mainProblem)
+                .build();
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/client/submit/dto/response/ProblemClientGetResponse.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/dto/response/ProblemClientGetResponse.java
@@ -15,9 +15,9 @@ public record ProblemClientGetResponse(
         ProblemSubmitStatus status,
         List<ChildProblemSubmitStatus> childProblemStatuses
 ) {
-    public static ProblemClientGetResponse of(Problem problem, ProblemSubmitStatus status, List<ChildProblemSubmitStatus> childProblemStatuses) {
+    public static ProblemClientGetResponse of(Problem problem, ProblemSubmitStatus status, List<ChildProblemSubmitStatus> childProblemStatuses, int number) {
         return ProblemClientGetResponse.builder()
-                .number(problem.getNumber())
+                .number(number)
                 .imageUrl(problem.getMainProblemImageUrl())
                 .status(status)
                 .childProblemStatuses(childProblemStatuses)

--- a/src/main/java/com/moplus/moplus_server/client/submit/dto/response/ProblemClientGetResponse.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/dto/response/ProblemClientGetResponse.java
@@ -1,0 +1,28 @@
+package com.moplus.moplus_server.client.submit.dto.response;
+
+import com.moplus.moplus_server.client.submit.domain.ChildProblemSubmitStatus;
+import com.moplus.moplus_server.client.submit.domain.ProblemSubmitStatus;
+import com.moplus.moplus_server.domain.problem.domain.problem.Problem;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record ProblemClientGetResponse(
+        int number,
+        String imageUrl,
+        Integer recommendedMinute,
+        Integer recommendedSecond,
+        ProblemSubmitStatus status,
+        List<ChildProblemSubmitStatus> childProblemStatuses
+) {
+    public static ProblemClientGetResponse of(Problem problem, ProblemSubmitStatus status, List<ChildProblemSubmitStatus> childProblemStatuses) {
+        return ProblemClientGetResponse.builder()
+                .number(problem.getNumber())
+                .imageUrl(problem.getMainProblemImageUrl())
+                .status(status)
+                .childProblemStatuses(childProblemStatuses)
+                .recommendedMinute(problem.getRecommendedTime().getMinute())
+                .recommendedSecond(problem.getRecommendedTime().getSecond())
+                .build();
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/client/submit/dto/response/ProblemDetailResponse.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/dto/response/ProblemDetailResponse.java
@@ -1,0 +1,20 @@
+package com.moplus.moplus_server.client.submit.dto.response;
+
+import com.moplus.moplus_server.client.submit.domain.ProblemSubmitStatus;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record ProblemDetailResponse(
+        String imageUrl,
+        List<String> prescriptionImageUrls,
+        ProblemSubmitStatus submitStatus
+) {
+    public static ProblemDetailResponse of(String imageUrl, List<String> prescriptionImageUrls, ProblemSubmitStatus submitStatus) {
+        return ProblemDetailResponse.builder()
+                .imageUrl(imageUrl)
+                .prescriptionImageUrls(prescriptionImageUrls)
+                .submitStatus(submitStatus)
+                .build();
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/client/submit/dto/response/ProblemDetailResponse.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/dto/response/ProblemDetailResponse.java
@@ -1,6 +1,7 @@
 package com.moplus.moplus_server.client.submit.dto.response;
 
 import com.moplus.moplus_server.client.submit.domain.ProblemSubmitStatus;
+import com.moplus.moplus_server.domain.problem.domain.problem.Problem;
 import java.util.List;
 import lombok.Builder;
 
@@ -10,10 +11,10 @@ public record ProblemDetailResponse(
         List<String> prescriptionImageUrls,
         ProblemSubmitStatus submitStatus
 ) {
-    public static ProblemDetailResponse of(String imageUrl, List<String> prescriptionImageUrls, ProblemSubmitStatus submitStatus) {
+    public static ProblemDetailResponse of(Problem problem, ProblemSubmitStatus submitStatus) {
         return ProblemDetailResponse.builder()
-                .imageUrl(imageUrl)
-                .prescriptionImageUrls(prescriptionImageUrls)
+                .imageUrl(problem.getMainProblemImageUrl())
+                .prescriptionImageUrls(problem.getPrescriptionImageUrls())
                 .submitStatus(submitStatus)
                 .build();
     }

--- a/src/main/java/com/moplus/moplus_server/client/submit/repository/ChildProblemSubmitRepository.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/repository/ChildProblemSubmitRepository.java
@@ -1,0 +1,16 @@
+package com.moplus.moplus_server.client.submit.repository;
+
+import com.moplus.moplus_server.client.submit.domain.ChildProblemSubmit;
+import com.moplus.moplus_server.global.error.exception.ErrorCode;
+import com.moplus.moplus_server.global.error.exception.NotFoundException;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChildProblemSubmitRepository extends JpaRepository<ChildProblemSubmit, Long> {
+    Optional<ChildProblemSubmit> findByMemberIdAndPublishIdAndChildProblemId(Long memberId, Long publishId, Long problemId);
+
+    default ChildProblemSubmit findByMemberIdAndPublishIdAndChildProblemIdElseThrow(Long memberId, Long publishId, Long problemId) {
+        return findByMemberIdAndPublishIdAndChildProblemId(memberId, publishId, problemId).orElseThrow(
+                () -> new NotFoundException(ErrorCode.CHILD_PROBLEM_SUBMIT_NOT_CONFIRMED));
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/client/submit/repository/ChildProblemSubmitRepository.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/repository/ChildProblemSubmitRepository.java
@@ -7,10 +7,10 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChildProblemSubmitRepository extends JpaRepository<ChildProblemSubmit, Long> {
-    Optional<ChildProblemSubmit> findByMemberIdAndPublishIdAndChildProblemId(Long memberId, Long publishId, Long problemId);
+    Optional<ChildProblemSubmit> findByMemberIdAndPublishIdAndChildProblemId(Long memberId, Long publishId, Long childProblemId);
 
-    default ChildProblemSubmit findByMemberIdAndPublishIdAndChildProblemIdElseThrow(Long memberId, Long publishId, Long problemId) {
-        return findByMemberIdAndPublishIdAndChildProblemId(memberId, publishId, problemId).orElseThrow(
+    default ChildProblemSubmit findByMemberIdAndPublishIdAndChildProblemIdElseThrow(Long memberId, Long publishId, Long childProblemId) {
+        return findByMemberIdAndPublishIdAndChildProblemId(memberId, publishId, childProblemId).orElseThrow(
                 () -> new NotFoundException(ErrorCode.CHILD_PROBLEM_SUBMIT_NOT_CONFIRMED));
     }
 }

--- a/src/main/java/com/moplus/moplus_server/client/submit/repository/ChildProblemSubmitRepository.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/repository/ChildProblemSubmitRepository.java
@@ -3,6 +3,7 @@ package com.moplus.moplus_server.client.submit.repository;
 import com.moplus.moplus_server.client.submit.domain.ChildProblemSubmit;
 import com.moplus.moplus_server.global.error.exception.ErrorCode;
 import com.moplus.moplus_server.global.error.exception.NotFoundException;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -13,4 +14,7 @@ public interface ChildProblemSubmitRepository extends JpaRepository<ChildProblem
         return findByMemberIdAndPublishIdAndChildProblemId(memberId, publishId, childProblemId).orElseThrow(
                 () -> new NotFoundException(ErrorCode.CHILD_PROBLEM_SUBMIT_NOT_CONFIRMED));
     }
+
+    List<ChildProblemSubmit> findAllByMemberIdAndPublishIdAndChildProblemIdIn(Long memberId, Long publishId,
+                                                                            List<Long> childProblemIds);
 }

--- a/src/main/java/com/moplus/moplus_server/client/submit/repository/ProblemSubmitRepository.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/repository/ProblemSubmitRepository.java
@@ -1,0 +1,9 @@
+package com.moplus.moplus_server.client.submit.repository;
+
+import com.moplus.moplus_server.client.submit.domain.ProblemSubmit;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProblemSubmitRepository extends JpaRepository<ProblemSubmit, Long> {
+    List<ProblemSubmit> findByMemberIdAndPublishId(Long memberId, Long publishId);
+}

--- a/src/main/java/com/moplus/moplus_server/client/submit/repository/ProblemSubmitRepository.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/repository/ProblemSubmitRepository.java
@@ -1,9 +1,19 @@
 package com.moplus.moplus_server.client.submit.repository;
 
 import com.moplus.moplus_server.client.submit.domain.ProblemSubmit;
+import com.moplus.moplus_server.global.error.exception.ErrorCode;
+import com.moplus.moplus_server.global.error.exception.NotFoundException;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProblemSubmitRepository extends JpaRepository<ProblemSubmit, Long> {
     List<ProblemSubmit> findByMemberIdAndPublishId(Long memberId, Long publishId);
+
+    Optional<ProblemSubmit> findByMemberIdAndPublishIdAndProblemId(Long memberId, Long publishId, Long problemId);
+
+    default ProblemSubmit findByMemberIdAndPublishIdAndProblemIdElseThrow(Long memberId, Long publishId, Long problemId) {
+        return findByMemberIdAndPublishIdAndProblemId(memberId, publishId, problemId).orElseThrow(
+                () -> new NotFoundException(ErrorCode.PROBLEM_SUBMIT_NOT_CONFIRMED));
+    }
 }

--- a/src/main/java/com/moplus/moplus_server/client/submit/service/ClientGetService.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/service/ClientGetService.java
@@ -1,0 +1,74 @@
+package com.moplus.moplus_server.client.submit.service;
+
+
+import com.moplus.moplus_server.admin.publish.domain.Publish;
+import com.moplus.moplus_server.client.submit.domain.ProblemSubmit;
+import com.moplus.moplus_server.client.submit.domain.ProblemSubmitStatus;
+import com.moplus.moplus_server.client.submit.dto.response.AllProblemGetResponse;
+import com.moplus.moplus_server.client.submit.dto.response.DayProgress;
+import com.moplus.moplus_server.client.submit.repository.ProblemSubmitRepository;
+import com.moplus.moplus_server.domain.problem.domain.problem.Problem;
+import com.moplus.moplus_server.domain.problem.repository.ProblemRepository;
+import com.moplus.moplus_server.domain.problemset.repository.ProblemSetRepository;
+import com.moplus.moplus_server.domain.publish.repository.PublishRepository;
+import com.moplus.moplus_server.global.error.exception.ErrorCode;
+import com.moplus.moplus_server.global.error.exception.InvalidValueException;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ClientGetService {
+
+    private final PublishRepository publishRepository;
+    private final ProblemSubmitRepository problemSubmitRepository;
+    private final ProblemRepository problemRepository;
+    private final ProblemSetRepository problemSetRepository;
+
+    @Transactional(readOnly = true)
+    public List<AllProblemGetResponse> getAllProblem(int year, int month) {
+
+        Long memberId = 1L;
+
+        if (month < 1 || month > 12) {
+            throw new InvalidValueException(ErrorCode.INVALID_MONTH_ERROR);
+        }
+        LocalDate startDate = LocalDate.of(year, month, 1);
+        LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth());
+
+        // 해당 월 모든 Publish 조회
+        List<Publish> publishes = publishRepository.findByPublishedDateBetween(startDate, endDate);
+
+        List<AllProblemGetResponse> result = new ArrayList<>();
+
+        for (Publish publish : publishes) {
+            Long publishId = publish.getId();
+            LocalDate date = publish.getPublishedDate();
+
+            // 날짜별 사용자 제출 정보 조회
+            List<ProblemSubmit> submissions = problemSubmitRepository.findByMemberIdAndPublishId(memberId, publishId);
+            List<ProblemSubmitStatus> problemStatuses = submissions.stream()
+                    .map(ProblemSubmit::getStatus)
+                    .toList();
+
+            // 사용자 제출 정보 바탕으로 진행도 결정
+            DayProgress progress = DayProgress.determineDayProgress(problemStatuses);
+            String mainProblemImageUrl = getMainProblemImageUrl(publish.getProblemSetId());
+
+            result.add(AllProblemGetResponse.of(publishId, date, progress, problemStatuses, mainProblemImageUrl));
+        }
+        return result;
+    }
+
+    private String getMainProblemImageUrl(Long problemSetId) {
+        return problemSetRepository.findById(problemSetId)
+                .flatMap(problemSet -> problemSet.getProblemIds().stream().findFirst())
+                .flatMap(problemRepository::findById)
+                .map(Problem::getMainProblemImageUrl)
+                .orElse(null);
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/client/submit/service/ClientGetService.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/service/ClientGetService.java
@@ -38,7 +38,6 @@ public class ClientGetService {
 
     @Transactional(readOnly = true)
     public CommentaryGetResponse getCommentary(Long publishId, Long problemId) {
-
         Long memberId = 1L;
 
         // 문항 제출 조회
@@ -78,7 +77,6 @@ public class ClientGetService {
 
     @Transactional(readOnly = true)
     public List<AllProblemGetResponse> getAllProblem(int year, int month) {
-
         Long memberId = 1L;
 
         if (month < 1 || month > 12) {

--- a/src/main/java/com/moplus/moplus_server/client/submit/service/ClientSubmitService.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/service/ClientSubmitService.java
@@ -7,6 +7,7 @@ import com.moplus.moplus_server.client.submit.domain.ProblemSubmit;
 import com.moplus.moplus_server.client.submit.domain.ProblemSubmitStatus;
 import com.moplus.moplus_server.client.submit.dto.request.ChildProblemSubmitCreateRequest;
 import com.moplus.moplus_server.client.submit.dto.request.ProblemSubmitCreateRequest;
+import com.moplus.moplus_server.client.submit.dto.request.ProblemSubmitUpdateRequest;
 import com.moplus.moplus_server.client.submit.repository.ChildProblemSubmitRepository;
 import com.moplus.moplus_server.client.submit.repository.ProblemSubmitRepository;
 import com.moplus.moplus_server.domain.problem.domain.childProblem.ChildProblem;
@@ -30,12 +31,10 @@ public class ClientSubmitService {
 
     @Transactional
     public void createProblemSubmit(ProblemSubmitCreateRequest request) {
-
         Long memberId = 1L;
 
         // 존재하는 발행인지 검증
         publishRepository.existsByIdElseThrow(request.publishId());
-
         // 존재하는 문항인지 검증
         problemRepository.existsByIdElseThrow(request.problemId());
 
@@ -49,13 +48,32 @@ public class ClientSubmitService {
     }
 
     @Transactional
-    public void createChildProblemSubmit(ChildProblemSubmitCreateRequest request) {
-
+    public ProblemSubmitStatus updateProblemSubmit(ProblemSubmitUpdateRequest request) {
         Long memberId = 1L;
 
         // 존재하는 발행인지 검증
         publishRepository.existsByIdElseThrow(request.publishId());
 
+        // 문항 조회
+        Problem problem = problemRepository.findByIdElseThrow(request.problemId());
+
+        //문항 제출 데이터 조회
+        ProblemSubmit problemSubmit = problemSubmitRepository.findByMemberIdAndPublishIdAndProblemIdElseThrow(memberId,
+                request.publishId(), request.problemId());
+        // 제출한 답안에 대한 상태 결정
+        ProblemSubmitStatus status = ProblemSubmitStatus.determineStatus(problemSubmit.getStatus(), request.answer(),
+                problem.getAnswer());
+
+        problemSubmit.updateStatus(status);
+        return status;
+    }
+
+    @Transactional
+    public void createChildProblemSubmit(ChildProblemSubmitCreateRequest request) {
+        Long memberId = 1L;
+
+        // 존재하는 발행인지 검증
+        publishRepository.existsByIdElseThrow(request.publishId());
         // 존재하는 문항인지 검증
         problemRepository.existsByIdElseThrow(request.problemId());
 

--- a/src/main/java/com/moplus/moplus_server/client/submit/service/ClientSubmitService.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/service/ClientSubmitService.java
@@ -6,6 +6,7 @@ import com.moplus.moplus_server.client.submit.domain.ChildProblemSubmitStatus;
 import com.moplus.moplus_server.client.submit.domain.ProblemSubmit;
 import com.moplus.moplus_server.client.submit.domain.ProblemSubmitStatus;
 import com.moplus.moplus_server.client.submit.dto.request.ChildProblemSubmitCreateRequest;
+import com.moplus.moplus_server.client.submit.dto.request.ChildProblemSubmitUpdateIncorrectRequest;
 import com.moplus.moplus_server.client.submit.dto.request.ChildProblemSubmitUpdateRequest;
 import com.moplus.moplus_server.client.submit.dto.request.ProblemSubmitCreateRequest;
 import com.moplus.moplus_server.client.submit.dto.request.ProblemSubmitUpdateRequest;
@@ -134,4 +135,20 @@ public class ClientSubmitService {
         return status;
     }
 
+    @Transactional
+    public void updateChildProblemSubmitIncorrect(ChildProblemSubmitUpdateIncorrectRequest request) {
+        Long memberId = 1L;
+
+        // 존재하는 발행인지 검증
+        publishRepository.existsByIdElseThrow(request.publishId());
+
+        // 새끼문항 조회
+        ChildProblem childProblem = childProblemRepository.findByIdElseThrow(request.childProblemId());
+
+        //새끼문항 제출 데이터 조회
+        ChildProblemSubmit childProblemSubmit = childProblemSubmitRepository.findByMemberIdAndPublishIdAndChildProblemIdElseThrow(memberId,
+                request.publishId(), request.childProblemId());
+        // 틀림 처리
+        childProblemSubmit.updateStatusIncorrect();
+    }
 }

--- a/src/main/java/com/moplus/moplus_server/client/submit/service/ClientSubmitService.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/service/ClientSubmitService.java
@@ -1,0 +1,30 @@
+package com.moplus.moplus_server.client.submit.service;
+
+
+import com.moplus.moplus_server.client.submit.domain.ProblemSubmit;
+import com.moplus.moplus_server.client.submit.dto.request.ProblemSubmitCreateRequest;
+import com.moplus.moplus_server.client.submit.repository.ProblemSubmitRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ClientSubmitService {
+
+    private final ProblemSubmitRepository problemSubmitRepository;
+
+    @Transactional
+    public void createProblemSubmit(ProblemSubmitCreateRequest request) {
+
+        Long memberId = 1L;
+        // 제출이력이 없을때만 생성
+        Optional<ProblemSubmit> existingProblemSubmit = problemSubmitRepository.findByMemberIdAndPublishIdAndProblemId(memberId,
+                request.publishId(), request.problemId());
+        if (existingProblemSubmit.isEmpty()) {
+            ProblemSubmit problemSubmit = request.toEntity(memberId);
+            problemSubmitRepository.save(problemSubmit);
+        }
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/client/submit/service/ClientSubmitService.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/service/ClientSubmitService.java
@@ -1,9 +1,19 @@
 package com.moplus.moplus_server.client.submit.service;
 
 
+import com.moplus.moplus_server.client.submit.domain.ChildProblemSubmit;
+import com.moplus.moplus_server.client.submit.domain.ChildProblemSubmitStatus;
 import com.moplus.moplus_server.client.submit.domain.ProblemSubmit;
+import com.moplus.moplus_server.client.submit.domain.ProblemSubmitStatus;
+import com.moplus.moplus_server.client.submit.dto.request.ChildProblemSubmitCreateRequest;
 import com.moplus.moplus_server.client.submit.dto.request.ProblemSubmitCreateRequest;
+import com.moplus.moplus_server.client.submit.repository.ChildProblemSubmitRepository;
 import com.moplus.moplus_server.client.submit.repository.ProblemSubmitRepository;
+import com.moplus.moplus_server.domain.problem.domain.childProblem.ChildProblem;
+import com.moplus.moplus_server.domain.problem.domain.problem.Problem;
+import com.moplus.moplus_server.domain.problem.repository.ProblemRepository;
+import com.moplus.moplus_server.domain.publish.repository.PublishRepository;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,11 +24,21 @@ import org.springframework.transaction.annotation.Transactional;
 public class ClientSubmitService {
 
     private final ProblemSubmitRepository problemSubmitRepository;
+    private final ProblemRepository problemRepository;
+    private final ChildProblemSubmitRepository childProblemSubmitRepository;
+    private final PublishRepository publishRepository;
 
     @Transactional
     public void createProblemSubmit(ProblemSubmitCreateRequest request) {
 
         Long memberId = 1L;
+
+        // 존재하는 발행인지 검증
+        publishRepository.existsByIdElseThrow(request.publishId());
+
+        // 존재하는 문항인지 검증
+        problemRepository.existsByIdElseThrow(request.problemId());
+
         // 제출이력이 없을때만 생성
         Optional<ProblemSubmit> existingProblemSubmit = problemSubmitRepository.findByMemberIdAndPublishIdAndProblemId(memberId,
                 request.publishId(), request.problemId());
@@ -27,4 +47,49 @@ public class ClientSubmitService {
             problemSubmitRepository.save(problemSubmit);
         }
     }
+
+    @Transactional
+    public void createChildProblemSubmit(ChildProblemSubmitCreateRequest request) {
+
+        Long memberId = 1L;
+
+        // 존재하는 발행인지 검증
+        publishRepository.existsByIdElseThrow(request.publishId());
+
+        // 존재하는 문항인지 검증
+        problemRepository.existsByIdElseThrow(request.problemId());
+
+        // 문항제출 이력이 없으면 문항제출 생성
+        Optional<ProblemSubmit> existingProblemSubmit = problemSubmitRepository.findByMemberIdAndPublishIdAndProblemId(memberId,
+                request.publishId(), request.problemId());
+        if (existingProblemSubmit.isEmpty()) {
+            ProblemSubmit problemSubmit = ProblemSubmit.builder()
+                    .memberId(memberId)
+                    .publishId(request.publishId())
+                    .problemId(request.problemId())
+                    .status(ProblemSubmitStatus.IN_PROGRESS)
+                    .build();
+            problemSubmitRepository.save(problemSubmit);
+        }
+
+        // 문항의 새끼문항 조회
+        Problem problem = problemRepository.findByIdElseThrow(request.problemId());
+        List<ChildProblem> childProblems = problem.getChildProblems();
+
+        // 제출이력이 없을떄만 생성
+        for (ChildProblem childProblem : childProblems) {
+            Long childProblemId = childProblem.getId();
+
+            Optional<ChildProblemSubmit> existingChildProblemSubmit = childProblemSubmitRepository.findByMemberIdAndPublishIdAndChildProblemId(memberId,
+                    request.publishId(), childProblemId);
+            ChildProblemSubmit childProblemSubmit = ChildProblemSubmit.builder()
+                    .memberId(memberId)
+                    .publishId(request.publishId())
+                    .childProblemId(childProblemId)
+                    .status(ChildProblemSubmitStatus.NOT_STARTED)
+                    .build();
+            childProblemSubmitRepository.save(childProblemSubmit);
+        }
+    }
+
 }

--- a/src/main/java/com/moplus/moplus_server/client/submit/service/CommentaryGetService.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/service/CommentaryGetService.java
@@ -47,8 +47,7 @@ public class CommentaryGetService {
         // 문항 해설 생성
         Problem problem = problemRepository.findByIdElseThrow(problemId);
         ProblemDetailResponse mainProblem = ProblemDetailResponse.of(
-                problem.getMainProblemImageUrl(),
-                problem.getPrescriptionImageUrls(),
+                problem,
                 problemSubmit.getStatus()
         );
 
@@ -74,11 +73,7 @@ public class CommentaryGetService {
 
         return CommentaryGetResponse.of(
                 number + 1,
-                problem.getAnswer(),
-                problem.getMainAnalysisImageUrl(),
-                problem.getMainHandwritingExplanationImageUrl(),
-                problem.getReadingTipImageUrl(),
-                problem.getSeniorTipImageUrl(),
+                problem,
                 prescription
         );
     }

--- a/src/main/java/com/moplus/moplus_server/client/submit/service/CommentaryGetService.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/service/CommentaryGetService.java
@@ -1,0 +1,91 @@
+package com.moplus.moplus_server.client.submit.service;
+
+import com.moplus.moplus_server.admin.publish.domain.Publish;
+import com.moplus.moplus_server.client.submit.domain.ProblemSubmit;
+import com.moplus.moplus_server.client.submit.dto.response.ChildProblemDetailResponse;
+import com.moplus.moplus_server.client.submit.dto.response.CommentaryGetResponse;
+import com.moplus.moplus_server.client.submit.dto.response.PrescriptionResponse;
+import com.moplus.moplus_server.client.submit.dto.response.ProblemDetailResponse;
+import com.moplus.moplus_server.client.submit.repository.ChildProblemSubmitRepository;
+import com.moplus.moplus_server.client.submit.repository.ProblemSubmitRepository;
+import com.moplus.moplus_server.domain.problem.domain.problem.Problem;
+import com.moplus.moplus_server.domain.problem.repository.ProblemRepository;
+import com.moplus.moplus_server.domain.problemset.domain.ProblemSet;
+import com.moplus.moplus_server.domain.problemset.repository.ProblemSetRepository;
+import com.moplus.moplus_server.domain.publish.repository.PublishRepository;
+import com.moplus.moplus_server.global.error.exception.ErrorCode;
+import com.moplus.moplus_server.global.error.exception.InvalidValueException;
+import com.moplus.moplus_server.global.error.exception.NotFoundException;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentaryGetService {
+
+    private final PublishRepository publishRepository;
+    private final ProblemSubmitRepository problemSubmitRepository;
+    private final ProblemRepository problemRepository;
+    private final ProblemSetRepository problemSetRepository;
+    private final ChildProblemSubmitRepository childProblemSubmitRepository;
+
+    @Transactional(readOnly = true)
+    public CommentaryGetResponse getCommentary(Long publishId, Long problemId) {
+        Long memberId = 1L;
+
+        // 발행 조회
+        Publish publish = publishRepository.findByIdElseThrow(publishId);
+        denyAccessToFuturePublish(publish);
+
+        // 문항 제출 조회
+        ProblemSubmit problemSubmit = problemSubmitRepository.findByMemberIdAndPublishIdAndProblemIdElseThrow(memberId,
+                publishId, problemId);
+
+        // 문항 해설 생성
+        Problem problem = problemRepository.findByIdElseThrow(problemId);
+        ProblemDetailResponse mainProblem = ProblemDetailResponse.of(
+                problem.getMainProblemImageUrl(),
+                problem.getPrescriptionImageUrls(),
+                problemSubmit.getStatus()
+        );
+
+        // 새끼문항 해설 생성
+        List<ChildProblemDetailResponse> childProblem = problem.getChildProblems().stream()
+                .map(cp -> ChildProblemDetailResponse.of(
+                        cp.getImageUrl(),
+                        cp.getPrescriptionImageUrls(),
+                        childProblemSubmitRepository.findByMemberIdAndPublishIdAndChildProblemIdElseThrow(memberId, publishId,
+                                cp.getId()).getStatus()
+                )).toList();
+
+        // 처방 정보 생성
+        PrescriptionResponse prescription = PrescriptionResponse.of(childProblem, mainProblem);
+
+        // 문항 번호 추출
+        ProblemSet problemSet = problemSetRepository.findByIdElseThrow(publish.getProblemSetId());
+        List<Long> problemIds = problemSet.getProblemIds();
+        int number = problemIds.indexOf(problemId);
+        if (number == -1) {
+            throw new NotFoundException(ErrorCode.PROBLEM_NOT_FOUND_IN_PROBLEM_SET);
+        }
+
+        return CommentaryGetResponse.of(
+                number + 1,
+                problem.getAnswer(),
+                problem.getMainAnalysisImageUrl(),
+                problem.getMainHandwritingExplanationImageUrl(),
+                problem.getReadingTipImageUrl(),
+                problem.getSeniorTipImageUrl(),
+                prescription
+        );
+    }
+
+    private void denyAccessToFuturePublish(Publish publish){
+        if (publish.getPublishedDate().isAfter(LocalDate.now())) {
+            throw new InvalidValueException(ErrorCode.FUTURE_PUBLISH_NOT_ACCESSIBLE);
+        }
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/client/submit/service/ProblemsGetService.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/service/ProblemsGetService.java
@@ -39,12 +39,14 @@ public class ProblemsGetService {
     private final ProblemSetRepository problemSetRepository;
     private final ChildProblemSubmitRepository childProblemSubmitRepository;
     private final ChildProblemRepository childProblemRepository;
+    private static final int MIN_MONTH = 1;
+    private static final int MAX_MONTH = 12;
 
     @Transactional(readOnly = true)
     public List<AllProblemGetResponse> getAllProblem(int year, int month) {
         Long memberId = 1L;
 
-        if (month < 1 || month > 12) {
+        if (month < MIN_MONTH || month > MAX_MONTH) {
             throw new InvalidValueException(ErrorCode.INVALID_MONTH_ERROR);
         }
         LocalDate startDate = LocalDate.of(year, month, 1);

--- a/src/main/java/com/moplus/moplus_server/client/submit/service/ProblemsGetService.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/service/ProblemsGetService.java
@@ -8,12 +8,8 @@ import com.moplus.moplus_server.client.submit.domain.ProblemSubmit;
 import com.moplus.moplus_server.client.submit.domain.ProblemSubmitStatus;
 import com.moplus.moplus_server.client.submit.dto.response.AllProblemGetResponse;
 import com.moplus.moplus_server.client.submit.dto.response.ChildProblemClientGetResponse;
-import com.moplus.moplus_server.client.submit.dto.response.ChildProblemDetailResponse;
-import com.moplus.moplus_server.client.submit.dto.response.CommentaryGetResponse;
 import com.moplus.moplus_server.client.submit.dto.response.DayProgress;
-import com.moplus.moplus_server.client.submit.dto.response.PrescriptionResponse;
 import com.moplus.moplus_server.client.submit.dto.response.ProblemClientGetResponse;
-import com.moplus.moplus_server.client.submit.dto.response.ProblemDetailResponse;
 import com.moplus.moplus_server.client.submit.repository.ChildProblemSubmitRepository;
 import com.moplus.moplus_server.client.submit.repository.ProblemSubmitRepository;
 import com.moplus.moplus_server.domain.problem.domain.childProblem.ChildProblem;
@@ -29,14 +25,13 @@ import com.moplus.moplus_server.global.error.exception.NotFoundException;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
-import javax.swing.undo.CannotUndoException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-public class ClientGetService {
+public class ProblemsGetService {
 
     private final PublishRepository publishRepository;
     private final ProblemSubmitRepository problemSubmitRepository;
@@ -44,57 +39,6 @@ public class ClientGetService {
     private final ProblemSetRepository problemSetRepository;
     private final ChildProblemSubmitRepository childProblemSubmitRepository;
     private final ChildProblemRepository childProblemRepository;
-
-    @Transactional(readOnly = true)
-    public CommentaryGetResponse getCommentary(Long publishId, Long problemId) {
-        Long memberId = 1L;
-
-        // 발행 조회
-        Publish publish = publishRepository.findByIdElseThrow(publishId);
-        denyAccessToFuturePublish(publish);
-
-        // 문항 제출 조회
-        ProblemSubmit problemSubmit = problemSubmitRepository.findByMemberIdAndPublishIdAndProblemIdElseThrow(memberId,
-                publishId, problemId);
-
-        // 문항 해설 생성
-        Problem problem = problemRepository.findByIdElseThrow(problemId);
-        ProblemDetailResponse mainProblem = ProblemDetailResponse.of(
-                problem.getMainProblemImageUrl(),
-                problem.getPrescriptionImageUrls(),
-                problemSubmit.getStatus()
-        );
-
-        // 새끼문항 해설 생성
-        List<ChildProblemDetailResponse> childProblem = problem.getChildProblems().stream()
-                .map(cp -> ChildProblemDetailResponse.of(
-                        cp.getImageUrl(),
-                        cp.getPrescriptionImageUrls(),
-                        childProblemSubmitRepository.findByMemberIdAndPublishIdAndChildProblemIdElseThrow(memberId, publishId,
-                                cp.getId()).getStatus()
-                )).toList();
-
-        // 처방 정보 생성
-        PrescriptionResponse prescription = PrescriptionResponse.of(childProblem, mainProblem);
-
-        // 문항 번호 추출
-        ProblemSet problemSet = problemSetRepository.findByIdElseThrow(publish.getProblemSetId());
-        List<Long> problemIds = problemSet.getProblemIds();
-        int number = problemIds.indexOf(problemId);
-        if (number == -1) {
-            throw new NotFoundException(ErrorCode.PROBLEM_NOT_FOUND_IN_PROBLEM_SET);
-        }
-
-        return CommentaryGetResponse.of(
-                number + 1,
-                problem.getAnswer(),
-                problem.getMainAnalysisImageUrl(),
-                problem.getMainHandwritingExplanationImageUrl(),
-                problem.getReadingTipImageUrl(),
-                problem.getSeniorTipImageUrl(),
-                prescription
-        );
-    }
 
     @Transactional(readOnly = true)
     public List<AllProblemGetResponse> getAllProblem(int year, int month) {

--- a/src/main/java/com/moplus/moplus_server/client/submit/service/ProblemsGetService.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/service/ProblemsGetService.java
@@ -137,15 +137,23 @@ public class ProblemsGetService {
         ChildProblemSubmit childProblemSubmit = childProblemSubmitRepository.findByMemberIdAndPublishIdAndChildProblemIdElseThrow(
                 memberId, publishId, childProblemId);
 
-        int sequence = 0;
+        int childProblemNumber = 0;
         for (int i = 0; i < problem.getChildProblems().size(); i++) {
             if (problem.getChildProblems().get(i).getId().equals(childProblemId)) {
-                sequence = i + 1;
+                childProblemNumber = i + 1;
                 break;
             }
         }
 
-        return ChildProblemClientGetResponse.of(problem.getNumber(), sequence, childProblem.getImageUrl(), childProblemSubmit.getStatus());
+        // 문항 번호 추출
+        ProblemSet problemSet = problemSetRepository.findByIdElseThrow(publish.getProblemSetId());
+        List<Long> problemIds = problemSet.getProblemIds();
+        int problemNumber = problemIds.indexOf(problemId);
+        if (problemNumber == -1) {
+            throw new NotFoundException(ErrorCode.PROBLEM_NOT_FOUND_IN_PROBLEM_SET);
+        }
+
+        return ChildProblemClientGetResponse.of(problemNumber + 1, childProblemNumber + 1, childProblem.getImageUrl(), childProblemSubmit.getStatus());
     }
 
     private void denyAccessToFuturePublish(Publish publish){

--- a/src/main/java/com/moplus/moplus_server/domain/problem/repository/ProblemRepository.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problem/repository/ProblemRepository.java
@@ -25,4 +25,5 @@ public interface ProblemRepository extends JpaRepository<Problem, Long> {
     default Problem findByIdElseThrow(Long id) {
         return findById(id).orElseThrow(() -> new NotFoundException(ErrorCode.PROBLEM_NOT_FOUND));
     }
+
 }

--- a/src/main/java/com/moplus/moplus_server/domain/publish/repository/PublishRepository.java
+++ b/src/main/java/com/moplus/moplus_server/domain/publish/repository/PublishRepository.java
@@ -15,4 +15,10 @@ public interface PublishRepository extends JpaRepository<Publish, Long> {
     }
 
     List<Publish> findByProblemSetId(Long problemSetId);
+
+    default void existsByIdElseThrow(Long id) {
+        if (!existsById(id)) {
+            throw new NotFoundException(ErrorCode.PUBLISH_NOT_FOUND);
+        }
+    }
 }

--- a/src/main/java/com/moplus/moplus_server/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/moplus/moplus_server/global/error/exception/ErrorCode.java
@@ -76,6 +76,12 @@ public enum ErrorCode {
     ALREADY_PUBLISHED_ERROR(HttpStatus.BAD_REQUEST, "이미 발행된 문항세트는 컨펌해제할 수 없습니다."),
     PROBLEM_SET_DELETED(HttpStatus.BAD_REQUEST, "삭제된 문항세트는 발행할 수 없습니다"),
     PROBLEM_SET_NOT_CONFIRMED(HttpStatus.BAD_REQUEST, "컨펌되지 않은 문항세트는 발행할 수 없습니다"),
+
+    // 문항 제출
+    PROBLEM_SUBMIT_NOT_CONFIRMED(HttpStatus.NOT_FOUND, "문항 제출 정보를 찾을 수 없습니다."),
+
+    // 새끼문항 제출
+    CHILD_PROBLEM_SUBMIT_NOT_CONFIRMED(HttpStatus.NOT_FOUND, "새끼문항 제출 정보를 찾을 수 없습니다."),
     ;
 
 

--- a/src/main/java/com/moplus/moplus_server/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/moplus/moplus_server/global/error/exception/ErrorCode.java
@@ -34,6 +34,7 @@ public enum ErrorCode {
     INVALID_SHORT_NUMBER_ANSWER(HttpStatus.BAD_REQUEST, "주관식 문항의 정답은 0~999 사이의 숫자여야 합니다"),
     INVALID_CONFIRM_PROBLEM(HttpStatus.BAD_REQUEST, "유효하지 않은 문항들 : "),
     INVALID_DIFFICULTY(HttpStatus.BAD_REQUEST, "난이도는 1~10 사이의 숫자여야 합니다"),
+    PROBLEM_NOT_FOUND_IN_PROBLEM_SET(HttpStatus.NOT_FOUND, "해당 날짜에 발행된 문항세트에 존재하는 문항이 아닙니다."),
 
     //새끼 문항
     CHILD_PROBLEM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 새끼 문제를 찾을 수 없습니다"),

--- a/src/main/java/com/moplus/moplus_server/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/moplus/moplus_server/global/error/exception/ErrorCode.java
@@ -76,6 +76,7 @@ public enum ErrorCode {
     ALREADY_PUBLISHED_ERROR(HttpStatus.BAD_REQUEST, "이미 발행된 문항세트는 컨펌해제할 수 없습니다."),
     PROBLEM_SET_DELETED(HttpStatus.BAD_REQUEST, "삭제된 문항세트는 발행할 수 없습니다"),
     PROBLEM_SET_NOT_CONFIRMED(HttpStatus.BAD_REQUEST, "컨펌되지 않은 문항세트는 발행할 수 없습니다"),
+    FUTURE_PUBLISH_NOT_ACCESSIBLE(HttpStatus.BAD_REQUEST, "오늘 이후의 발행을 조회할 수 없습니다."),
 
     // 문항 제출
     PROBLEM_SUBMIT_NOT_CONFIRMED(HttpStatus.NOT_FOUND, "문항 제출 정보를 찾을 수 없습니다."),


### PR DESCRIPTION
# 💡 Issue
- resolved: #94 
# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->
- 전체문제 조회
- 바로 풀러가기 : 문항 제출 생성(진행중으로)
- 단계별로 풀러가기 : 새끼문항 제출 생성(시작전으로)
- 문항 제출 상태 변경
- 새끼문항 제출 상테 변경
- 새끼문항 스킵(틀림 처리)
- 해설 조회
- 사용자 문항 조회
- 사용자 새끼문항 조회

# 💬 To Reviewers
<!-- 리뷰어들에게 남기고 싶은 말을 적어주세요
ex) 코드 리뷰 간 참고사항, 질문 등 -->
- 새끼문항에 '시작전' 상태가 추가되었습니다.
- 프론트엔드 개발자와 논의 한 후, 단계별로 풀러가기를 눌렀을 떄 새끼문항제출 데이터들이 생성되는 것이 자연스럽다고 생각했습니다.
- 현재 로그인 기능이 없어서, 모든 api의 memberId는 1을 기준으로 구현되었습니다.
- 추후 로그인 기능 추가 후, 일괄 변경하겠습니다.