### PR TITLE
[feat/98] 이번주 문제 영역 조회

### DIFF
--- a/src/main/generated/com/moplus/moplus_server/domain/problem/service/mapper/ChildProblemMapperImpl.java
+++ b/src/main/generated/com/moplus/moplus_server/domain/problem/service/mapper/ChildProblemMapperImpl.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2025-03-14T20:25:51+0900",
+    date = "2025-03-24T01:02:22+0900",
     comments = "version: 1.6.3, compiler: javac, environment: Java 17.0.10 (JetBrains s.r.o.)"
 )
 @Component

--- a/src/main/generated/com/moplus/moplus_server/domain/problem/service/mapper/ProblemMapperImpl.java
+++ b/src/main/generated/com/moplus/moplus_server/domain/problem/service/mapper/ProblemMapperImpl.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2025-03-15T21:23:23+0900",
+    date = "2025-03-24T01:02:22+0900",
     comments = "version: 1.6.3, compiler: javac, environment: Java 17.0.10 (JetBrains s.r.o.)"
 )
 @Component

--- a/src/main/java/com/moplus/moplus_server/admin/publish/service/PublishGetService.java
+++ b/src/main/java/com/moplus/moplus_server/admin/publish/service/PublishGetService.java
@@ -8,7 +8,6 @@ import com.moplus.moplus_server.domain.problemset.repository.ProblemSetRepositor
 import com.moplus.moplus_server.domain.publish.repository.PublishRepository;
 import com.moplus.moplus_server.global.error.exception.ErrorCode;
 import com.moplus.moplus_server.global.error.exception.InvalidValueException;
-import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
@@ -66,15 +65,7 @@ public class PublishGetService {
     }
 
     @Transactional(readOnly = true)
-    public List<Publish> getCurrentWeekPublishes() {
-        LocalDate today = LocalDate.now();
-        LocalDate startOfWeek = today.with(DayOfWeek.MONDAY);
-        LocalDate endOfWeek = today.with(DayOfWeek.FRIDAY);
-
-        return getWeeklyPublishes(startOfWeek, endOfWeek);
-    }
-
-    private List<Publish> getWeeklyPublishes(LocalDate startDate, LocalDate endDate) {
+    public List<Publish> getPublishesBetweenDates(LocalDate startDate, LocalDate endDate) {
         return publishRepository.findByPublishedDateBetween(startDate, endDate);
     }
 }

--- a/src/main/java/com/moplus/moplus_server/admin/publish/service/PublishGetService.java
+++ b/src/main/java/com/moplus/moplus_server/admin/publish/service/PublishGetService.java
@@ -1,13 +1,14 @@
 package com.moplus.moplus_server.admin.publish.service;
 
-import com.moplus.moplus_server.domain.problemset.domain.ProblemSet;
-import com.moplus.moplus_server.domain.problemset.repository.ProblemSetRepository;
 import com.moplus.moplus_server.admin.publish.domain.Publish;
 import com.moplus.moplus_server.admin.publish.dto.response.PublishMonthGetResponse;
 import com.moplus.moplus_server.admin.publish.dto.response.PublishProblemSetResponse;
+import com.moplus.moplus_server.domain.problemset.domain.ProblemSet;
+import com.moplus.moplus_server.domain.problemset.repository.ProblemSetRepository;
 import com.moplus.moplus_server.domain.publish.repository.PublishRepository;
 import com.moplus.moplus_server.global.error.exception.ErrorCode;
 import com.moplus.moplus_server.global.error.exception.InvalidValueException;
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
@@ -42,6 +43,7 @@ public class PublishGetService {
                 .collect(Collectors.toList());
     }
 
+
     private Map<Long, ProblemSet> getProblemSetMap(List<Publish> publishes) {
         List<Long> problemSetIds = publishes.stream()
                 .map(Publish::getProblemSetId)
@@ -61,5 +63,18 @@ public class PublishGetService {
                 publish,
                 PublishProblemSetResponse.of(problemSet)
         );
+    }
+
+    @Transactional(readOnly = true)
+    public List<Publish> getCurrentWeekPublishes() {
+        LocalDate today = LocalDate.now();
+        LocalDate startOfWeek = today.with(DayOfWeek.MONDAY);
+        LocalDate endOfWeek = today.with(DayOfWeek.FRIDAY);
+
+        return getWeeklyPublishes(startOfWeek, endOfWeek);
+    }
+
+    private List<Publish> getWeeklyPublishes(LocalDate startDate, LocalDate endDate) {
+        return publishRepository.findByPublishedDateBetween(startDate, endDate);
     }
 }

--- a/src/main/java/com/moplus/moplus_server/client/homefeed/controller/HomeFeedController.java
+++ b/src/main/java/com/moplus/moplus_server/client/homefeed/controller/HomeFeedController.java
@@ -1,0 +1,27 @@
+package com.moplus.moplus_server.client.homefeed.controller;
+
+import com.moplus.moplus_server.client.homefeed.dto.response.HomeFeedResponse;
+import com.moplus.moplus_server.client.homefeed.service.HomeFeedFacadeService;
+import com.moplus.moplus_server.global.annotation.AuthUser;
+import com.moplus.moplus_server.member.domain.Member;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "홈 피드 조회", description = "홈 피드 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/client/home-feed")
+public class HomeFeedController {
+
+    private final HomeFeedFacadeService homeFeedFacadeService;
+
+    @Operation(summary = "홈 피드 조회", description = "회원의 홈 피드 정보를 조회합니다.")
+    @GetMapping("")
+    public HomeFeedResponse getHomeFeed(@AuthUser Member member) {
+        return homeFeedFacadeService.getHomeFeed(member);
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/client/homefeed/dto/response/HomeFeedResponse.java
+++ b/src/main/java/com/moplus/moplus_server/client/homefeed/dto/response/HomeFeedResponse.java
@@ -1,0 +1,68 @@
+package com.moplus.moplus_server.client.homefeed.dto.response;
+
+import com.moplus.moplus_server.admin.problemset.dto.response.ProblemSetGetResponse;
+import com.moplus.moplus_server.admin.problemset.dto.response.ProblemSummaryResponse;
+import java.time.LocalDate;
+import java.util.List;
+
+public record HomeFeedResponse(
+        List<DailyProgressResponse> dailyProgresses,
+        List<ProblemSetHomeFeedResponse> problemSets
+) {
+    public static HomeFeedResponse of(
+            List<DailyProgressResponse> dailyProgresses,
+            List<ProblemSetHomeFeedResponse> problemSets
+    ) {
+        return new HomeFeedResponse(dailyProgresses, problemSets);
+    }
+
+    public record DailyProgressResponse(
+            LocalDate date,
+            double progressRate
+    ) {
+        public static DailyProgressResponse of(LocalDate date, double progressRate) {
+            return new DailyProgressResponse(date, progressRate);
+        }
+    }
+
+    public record ProblemSetHomeFeedResponse(
+            LocalDate date,
+            Long problemSetId,
+            String title,
+            Long submitCount,
+            ProblemHomeFeedResponse problemHomeFeedResponse
+    ) {
+        public static ProblemSetHomeFeedResponse of(LocalDate date, ProblemSetGetResponse problemSetGetResponse,
+                                                    Long submitCount) {
+            return new ProblemSetHomeFeedResponse(
+                    date,
+                    problemSetGetResponse.id(),
+                    problemSetGetResponse.title(),
+                    submitCount,
+                    ProblemHomeFeedResponse.of(problemSetGetResponse.problemSummaries().get(0))
+            );
+        }
+
+        public static ProblemSetHomeFeedResponse of(LocalDate date) {
+            return new ProblemSetHomeFeedResponse(
+                    date,
+                    null,
+                    null,
+                    null,
+                    null
+            );
+        }
+    }
+
+    public record ProblemHomeFeedResponse(
+            Long problemId,
+            String mainProblemImageUrl
+    ) {
+        public static ProblemHomeFeedResponse of(ProblemSummaryResponse problemSummaryResponse) {
+            return new ProblemHomeFeedResponse(
+                    problemSummaryResponse.problemId(),
+                    problemSummaryResponse.mainProblemImageUrl()
+            );
+        }
+    }
+} 

--- a/src/main/java/com/moplus/moplus_server/client/homefeed/service/HomeFeedFacadeService.java
+++ b/src/main/java/com/moplus/moplus_server/client/homefeed/service/HomeFeedFacadeService.java
@@ -44,7 +44,7 @@ public class HomeFeedFacadeService {
         LocalDate friday = today.with(DayOfWeek.FRIDAY);
 
         // 월요일부터 금요일까지의 발행된 문제 세트 조회
-        List<Publish> publishes = publishGetService.getCurrentWeekPublishes();
+        List<Publish> publishes = publishGetService.getPublishesBetweenDates(monday, friday);
         Map<LocalDate, Publish> publishByDate = publishes.stream()
                 .collect(Collectors.toMap(Publish::getPublishedDate, publish -> publish));
 

--- a/src/main/java/com/moplus/moplus_server/client/homefeed/service/HomeFeedFacadeService.java
+++ b/src/main/java/com/moplus/moplus_server/client/homefeed/service/HomeFeedFacadeService.java
@@ -1,0 +1,75 @@
+package com.moplus.moplus_server.client.homefeed.service;
+
+import com.moplus.moplus_server.admin.problemset.dto.response.ProblemSetGetResponse;
+import com.moplus.moplus_server.admin.publish.domain.Publish;
+import com.moplus.moplus_server.admin.publish.service.PublishGetService;
+import com.moplus.moplus_server.client.homefeed.dto.response.HomeFeedResponse;
+import com.moplus.moplus_server.client.homefeed.dto.response.HomeFeedResponse.DailyProgressResponse;
+import com.moplus.moplus_server.client.homefeed.dto.response.HomeFeedResponse.ProblemSetHomeFeedResponse;
+import com.moplus.moplus_server.domain.problemset.service.ProblemSetGetService;
+import com.moplus.moplus_server.member.domain.Member;
+import com.moplus.moplus_server.statistic.Problem.domain.ProblemSetStatistic;
+import com.moplus.moplus_server.statistic.Problem.repository.ProblemSetStatisticRepository;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class HomeFeedFacadeService {
+
+    private final ProblemSetStatisticRepository problemSetStatisticRepository;
+    private final PublishGetService publishGetService;
+    private final ProblemSetGetService problemSetGetService;
+
+    @Transactional(readOnly = true)
+    public HomeFeedResponse getHomeFeed(Member member) {
+        Long memberId = member.getId();
+
+        List<DailyProgressResponse> dailyProgresses = new ArrayList<>(); // 다음 PR에서 구현
+        List<ProblemSetHomeFeedResponse> problemSets = getWeekdayProblemSets();
+
+        return HomeFeedResponse.of(dailyProgresses, problemSets);
+    }
+
+    private List<ProblemSetHomeFeedResponse> getWeekdayProblemSets() {
+        LocalDate today = LocalDate.now();
+        LocalDate monday = today.with(DayOfWeek.MONDAY);
+        LocalDate friday = today.with(DayOfWeek.FRIDAY);
+
+        // 월요일부터 금요일까지의 발행된 문제 세트 조회
+        List<Publish> publishes = publishGetService.getCurrentWeekPublishes();
+        Map<LocalDate, Publish> publishByDate = publishes.stream()
+                .collect(Collectors.toMap(Publish::getPublishedDate, publish -> publish));
+
+        // 문제 세트 정보 조회
+        List<Long> problemSetIds = publishes.stream()
+                .map(Publish::getProblemSetId)
+                .toList();
+        Map<Long, ProblemSetGetResponse> problemSetMap = problemSetGetService.getProblemSets(problemSetIds).stream()
+                .collect(Collectors.toMap(ProblemSetGetResponse::id, response -> response));
+
+        // 월요일부터 금요일까지의 모든 날짜에 대한 응답 생성
+        List<ProblemSetHomeFeedResponse> responses = new ArrayList<>();
+        for (LocalDate date = monday; !date.isAfter(friday); date = date.plusDays(1)) {
+            Publish publish = publishByDate.get(date);
+            if (publish != null) {
+                ProblemSetGetResponse problemSet = problemSetMap.get(publish.getProblemSetId());
+                Long submitCount = problemSetStatisticRepository.findById(problemSet.id())
+                        .map(ProblemSetStatistic::getSubmitCount)
+                        .orElse(0L);
+                responses.add(ProblemSetHomeFeedResponse.of(date, problemSet, submitCount));
+            } else {
+                responses.add(ProblemSetHomeFeedResponse.of(date));
+            }
+        }
+
+        return responses;
+    }
+} 

--- a/src/main/java/com/moplus/moplus_server/client/submit/repository/ProblemSubmitRepository.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/repository/ProblemSubmitRepository.java
@@ -12,8 +12,9 @@ public interface ProblemSubmitRepository extends JpaRepository<ProblemSubmit, Lo
 
     Optional<ProblemSubmit> findByMemberIdAndPublishIdAndProblemId(Long memberId, Long publishId, Long problemId);
 
-    default ProblemSubmit findByMemberIdAndPublishIdAndProblemIdElseThrow(Long memberId, Long publishId, Long problemId) {
+    default ProblemSubmit findByMemberIdAndPublishIdAndProblemIdElseThrow(Long memberId, Long publishId,
+                                                                          Long problemId) {
         return findByMemberIdAndPublishIdAndProblemId(memberId, publishId, problemId).orElseThrow(
                 () -> new NotFoundException(ErrorCode.PROBLEM_SUBMIT_NOT_CONFIRMED));
     }
-}
+} 

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/service/ProblemSetGetService.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/service/ProblemSetGetService.java
@@ -1,14 +1,14 @@
 package com.moplus.moplus_server.domain.problemset.service;
 
+import com.moplus.moplus_server.admin.problemset.dto.response.ProblemSetGetResponse;
+import com.moplus.moplus_server.admin.problemset.dto.response.ProblemSummaryResponse;
+import com.moplus.moplus_server.admin.publish.domain.Publish;
 import com.moplus.moplus_server.domain.concept.domain.ConceptTag;
 import com.moplus.moplus_server.domain.concept.repository.ConceptTagRepository;
 import com.moplus.moplus_server.domain.problem.domain.problem.Problem;
 import com.moplus.moplus_server.domain.problem.repository.ProblemRepository;
 import com.moplus.moplus_server.domain.problemset.domain.ProblemSet;
-import com.moplus.moplus_server.admin.problemset.dto.response.ProblemSetGetResponse;
-import com.moplus.moplus_server.admin.problemset.dto.response.ProblemSummaryResponse;
 import com.moplus.moplus_server.domain.problemset.repository.ProblemSetRepository;
-import com.moplus.moplus_server.admin.publish.domain.Publish;
 import com.moplus.moplus_server.domain.publish.repository.PublishRepository;
 import com.moplus.moplus_server.global.error.exception.BusinessException;
 import com.moplus.moplus_server.global.error.exception.ErrorCode;
@@ -54,5 +54,12 @@ public class ProblemSetGetService {
             problemSummaries.add(ProblemSummaryResponse.of(problem, tagNames));
         }
         return ProblemSetGetResponse.of(problemSet, publishedDates, problemSummaries);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ProblemSetGetResponse> getProblemSets(List<Long> problemSetIds) {
+        return problemSetIds.stream()
+                .map(this::getProblemSet)
+                .toList();
     }
 }

--- a/src/main/java/com/moplus/moplus_server/statistic/Problem/service/CountStatisticsGetService.java
+++ b/src/main/java/com/moplus/moplus_server/statistic/Problem/service/CountStatisticsGetService.java
@@ -1,0 +1,18 @@
+package com.moplus.moplus_server.statistic.Problem.service;
+
+import com.moplus.moplus_server.statistic.Problem.repository.ProblemSetStatisticRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CountStatisticsGetService {
+
+    private final ProblemSetStatisticRepository problemSetStatisticRepository;
+
+    @Transactional(readOnly = true)
+    public Long getProblemSetCount(Long id) {
+        return problemSetStatisticRepository.findByIdElseThrow(id).getSubmitCount();
+    }
+}


### PR DESCRIPTION
# 💡 Issue
- resolved: #98 

<img width="285" alt="image" src="https://github.com/user-attachments/assets/a776f7c9-9930-470e-a251-7d6591617a01" />


# 📄 Description
- 홈피드에서는 이번주 진척도와 이번주에 발행된 (월,화,수,목,금)에 대한 문제 세트의 첫번째 문항을 보여주고 있어요
- 이번 pr에서는 이번주에 발행된 문제세트 정보를 내려주는 로직만 추가했어요

