### PR TITLE
Feature/#100 이번주 진척도 표시

### DIFF
--- a/src/main/java/com/moplus/moplus_server/client/homefeed/dto/response/HomeFeedResponse.java
+++ b/src/main/java/com/moplus/moplus_server/client/homefeed/dto/response/HomeFeedResponse.java
@@ -2,6 +2,7 @@ package com.moplus.moplus_server.client.homefeed.dto.response;
 
 import com.moplus.moplus_server.admin.problemset.dto.response.ProblemSetGetResponse;
 import com.moplus.moplus_server.admin.problemset.dto.response.ProblemSummaryResponse;
+import com.moplus.moplus_server.client.submit.domain.ProgressStatus;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -18,10 +19,10 @@ public record HomeFeedResponse(
 
     public record DailyProgressResponse(
             LocalDate date,
-            double progressRate
+            ProgressStatus progressStatus
     ) {
-        public static DailyProgressResponse of(LocalDate date, double progressRate) {
-            return new DailyProgressResponse(date, progressRate);
+        public static DailyProgressResponse of(LocalDate date, ProgressStatus progressStatus) {
+            return new DailyProgressResponse(date, progressStatus);
         }
     }
 

--- a/src/main/java/com/moplus/moplus_server/client/submit/domain/ProgressStatus.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/domain/ProgressStatus.java
@@ -1,0 +1,7 @@
+package com.moplus.moplus_server.client.submit.domain;
+
+public enum ProgressStatus {
+    COMPLETED,
+    IN_PROGRESS,
+    NOT_STARTED
+} 

--- a/src/main/java/com/moplus/moplus_server/client/submit/service/ProblemSubmitGetService.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/service/ProblemSubmitGetService.java
@@ -1,0 +1,50 @@
+package com.moplus.moplus_server.client.submit.service;
+
+import com.moplus.moplus_server.admin.publish.domain.Publish;
+import com.moplus.moplus_server.client.submit.domain.ProblemSubmit;
+import com.moplus.moplus_server.client.submit.domain.ProgressStatus;
+import com.moplus.moplus_server.client.submit.repository.ProblemSubmitRepository;
+import com.moplus.moplus_server.domain.problemset.domain.ProblemSet;
+import com.moplus.moplus_server.domain.problemset.repository.ProblemSetRepository;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ProblemSubmitGetService {
+
+    private final ProblemSubmitRepository problemSubmitRepository;
+    private final ProblemSetRepository problemSetRepository;
+
+    @Transactional(readOnly = true)
+    public ProgressStatus getProgressStatus(Long memberId, Long publishId) {
+        List<ProblemSubmit> submits = problemSubmitRepository.findByMemberIdAndPublishId(memberId, publishId);
+
+        if (submits.isEmpty()) {
+            return ProgressStatus.NOT_STARTED;
+        }
+
+        ProblemSet problemSet = problemSetRepository.findByIdElseThrow(submits.get(0).getProblemId());
+
+        int totalProblems = problemSet.getProblemIds().size();
+
+        if (submits.size() == totalProblems) {
+            return ProgressStatus.COMPLETED;
+        }
+        return ProgressStatus.IN_PROGRESS;
+    }
+
+    @Transactional(readOnly = true)
+    public Map<LocalDate, ProgressStatus> getProgressStatuses(Long memberId, List<Publish> publishes) {
+        return publishes.stream()
+                .collect(Collectors.toMap(
+                    Publish::getPublishedDate,
+                    publish -> getProgressStatus(memberId, publish.getId())
+                ));
+    }
+} 


### PR DESCRIPTION
# 💡 Issue
- resolved: #100 

# 📄 Description
- 홈 피드에 이번주 진척도에 대한 데이터가 같이 내려가요
- 데이터 형식은 아래와 같아요

```json
{
  "data": {
    "dailyProgresses": [
      {
        "date": "2025-03-24",
        "progressStatus": "NOT_STARTED"
      },
      {
        "date": "2025-03-25",
        "progressStatus": "NOT_STARTED"
      },
      {
        "date": "2025-03-26",
        "progressStatus": "NOT_STARTED"
      },
      {
        "date": "2025-03-27",
        "progressStatus": "NOT_STARTED"
      },
      {
        "date": "2025-03-28",
        "progressStatus": "NOT_STARTED"
      }
    ],
    "problemSets": [
      {
        "date": "2025-03-24",
        "problemSetId": null,
        "title": null,
        "submitCount": null,
        "problemHomeFeedResponse": null
      },
      {
        "date": "2025-03-25",
        "problemSetId": null,
        "title": null,
        "submitCount": null,
        "problemHomeFeedResponse": null
      },
      {
        "date": "2025-03-26",
        "problemSetId": null,
        "title": null,
        "submitCount": null,
        "problemHomeFeedResponse": null
      },
      {
        "date": "2025-03-27",
        "problemSetId": null,
        "title": null,
        "submitCount": null,
        "problemHomeFeedResponse": null
      },
      {
        "date": "2025-03-28",
        "problemSetId": null,
        "title": null,
        "submitCount": null,
        "problemHomeFeedResponse": null
      }
    ]
  }
}
```
