### PR TITLE
[feat/#104] 문항 썸네일 조회 api

### DIFF
--- a/src/main/java/com/moplus/moplus_server/client/problem/controller/ProblemGetController.java
+++ b/src/main/java/com/moplus/moplus_server/client/problem/controller/ProblemGetController.java
@@ -3,6 +3,7 @@ package com.moplus.moplus_server.client.problem.controller;
 import com.moplus.moplus_server.client.problem.dto.response.AllProblemGetResponse;
 import com.moplus.moplus_server.client.problem.dto.response.ChildProblemClientGetResponse;
 import com.moplus.moplus_server.client.problem.dto.response.ProblemClientGetResponse;
+import com.moplus.moplus_server.client.problem.dto.response.ProblemThumbnailResponse;
 import com.moplus.moplus_server.client.problem.dto.response.PublishClientGetResponse;
 import com.moplus.moplus_server.client.problem.service.ProblemsGetService;
 import com.moplus.moplus_server.global.annotation.AuthUser;
@@ -64,5 +65,14 @@ public class ProblemGetController {
     ) {
         return ResponseEntity.ok(
                 problemsGetService.getChildProblem(member.getId(), publishId, problemId, childProblemId));
+    }
+
+    @GetMapping("problem/thumbnail/{publishId}/{number}")
+    @Operation(summary = "문항 썸네일 조회", description = "바로 풀어보기/단계별로 풀어보기 화면에서 필요한 문항을 조회합니다.")
+    public ResponseEntity<ProblemThumbnailResponse> getProblemThumbnail(
+            @PathVariable Long publishId,
+            @PathVariable int number
+    ) {
+        return ResponseEntity.ok(problemsGetService.getProblemThumbnail(publishId, number));
     }
 }

--- a/src/main/java/com/moplus/moplus_server/client/problem/dto/response/ProblemThumbnailResponse.java
+++ b/src/main/java/com/moplus/moplus_server/client/problem/dto/response/ProblemThumbnailResponse.java
@@ -1,0 +1,21 @@
+package com.moplus.moplus_server.client.problem.dto.response;
+
+import com.moplus.moplus_server.domain.problem.domain.problem.Problem;
+import lombok.Builder;
+
+@Builder
+public record ProblemThumbnailResponse(
+        int number,
+        String imageUrl,
+        Integer recommendedMinute,
+        Integer recommendedSecond
+) {
+    public static ProblemThumbnailResponse of(int number, Problem problem) {
+        return ProblemThumbnailResponse.builder()
+                .number(number)
+                .imageUrl(problem.getMainProblemImageUrl())
+                .recommendedMinute(problem.getRecommendedTime().getMinute())
+                .recommendedSecond(problem.getRecommendedTime().getSecond())
+                .build();
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/client/problem/service/ProblemsGetService.java
+++ b/src/main/java/com/moplus/moplus_server/client/problem/service/ProblemsGetService.java
@@ -6,6 +6,7 @@ import com.moplus.moplus_server.client.problem.dto.response.AllProblemGetRespons
 import com.moplus.moplus_server.client.problem.dto.response.ChildProblemClientGetResponse;
 import com.moplus.moplus_server.client.problem.dto.response.ProblemClientGetResponse;
 import com.moplus.moplus_server.client.problem.dto.response.ProblemFeedProgressesGetResponse;
+import com.moplus.moplus_server.client.problem.dto.response.ProblemThumbnailResponse;
 import com.moplus.moplus_server.client.problem.dto.response.PublishClientGetResponse;
 import com.moplus.moplus_server.client.submit.domain.ChildProblemSubmit;
 import com.moplus.moplus_server.client.submit.domain.ChildProblemSubmitStatus;
@@ -213,5 +214,26 @@ public class ProblemsGetService {
         }
 
         return ProblemFeedProgressesGetResponse.of(problemStatus, childProblemStatuses, number);
+    }
+
+    @Transactional(readOnly = true)
+    public ProblemThumbnailResponse getProblemThumbnail(Long publishId, int number) {
+        // 발행 조회
+        Publish publish = publishRepository.findByIdElseThrow(publishId);
+        denyAccessToFuturePublish(publish);
+
+        // 문항 세트 조회
+        ProblemSet problemSet = problemSetRepository.findByIdElseThrow(publish.getProblemSetId());
+        List<Long> problemIds = problemSet.getProblemIds();
+
+        int index = number - 1;
+        if (index < 0 || index >= problemIds.size()) {
+            throw new NotFoundException(ErrorCode.PROBLEM_NUMBER_NOT_FOUND);
+        }
+
+        //문항 조회
+        Long problemId = problemIds.get(index);
+        Problem problem = problemRepository.findByIdElseThrow(problemId);
+        return ProblemThumbnailResponse.of(number, problem);
     }
 }

--- a/src/main/java/com/moplus/moplus_server/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/moplus/moplus_server/global/error/exception/ErrorCode.java
@@ -35,6 +35,7 @@ public enum ErrorCode {
     INVALID_CONFIRM_PROBLEM(HttpStatus.BAD_REQUEST, "유효하지 않은 문항들 : "),
     INVALID_DIFFICULTY(HttpStatus.BAD_REQUEST, "난이도는 1~10 사이의 숫자여야 합니다"),
     PROBLEM_NOT_FOUND_IN_PROBLEM_SET(HttpStatus.NOT_FOUND, "해당 날짜에 발행된 문항세트에 존재하는 문항이 아닙니다."),
+    PROBLEM_NUMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "번호에 해당하는 문항을 찾을 수 없습니다."),
 
     //새끼 문항
     CHILD_PROBLEM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 새끼 문제를 찾을 수 없습니다"),


### PR DESCRIPTION
# 💡 Issue
- resolved: #104 

# 📸 Screenshot
<!-- 필요 시 사진, 동영상 등을 첨부해 주세요
ex) 포스트맨, 스웨거, 로그 등 -->
<img width="386" alt="image" src="https://github.com/user-attachments/assets/5138f54e-1700-407f-9f02-c8f1c6aaa9d4" />


# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->
- 바로 풀어보기/단계별로 풀어보기 화면에서 필요한 문항 조회를 구현했어요.
- 문제 풀러가기 뷰에서 조회한 발행id와 문항번호를 통해서 조회돼요.
- 데이터 형식은 다음과 같아요.
```json
{
  "data": {
    "number": 1,
    "imageUrl": "https://s3-moplus.s3.ap-northeast-2.amazonaws.com/problems/1/main-problem/d989f0a8-5249-4526-8602-b41a5fdcfcc7.jpg",
    "recommendedMinute": 2,
    "recommendedSecond": 40
  }
}
```
