### PR TITLE
[feat/#111] 문항에 포함된 새끼문항ID들 조회

### DIFF
--- a/src/main/java/com/moplus/moplus_server/client/problem/controller/ProblemGetController.java
+++ b/src/main/java/com/moplus/moplus_server/client/problem/controller/ProblemGetController.java
@@ -2,6 +2,7 @@ package com.moplus.moplus_server.client.problem.controller;
 
 import com.moplus.moplus_server.client.problem.dto.response.AllProblemGetResponse;
 import com.moplus.moplus_server.client.problem.dto.response.ChildProblemClientGetResponse;
+import com.moplus.moplus_server.client.problem.dto.response.ChildProblemsClientGetResponse;
 import com.moplus.moplus_server.client.problem.dto.response.ProblemClientGetResponse;
 import com.moplus.moplus_server.client.problem.dto.response.ProblemClientThumbnailResponse;
 import com.moplus.moplus_server.client.problem.dto.response.PublishClientGetResponse;
@@ -74,5 +75,14 @@ public class ProblemGetController {
             @PathVariable Long problemId
     ) {
         return ResponseEntity.ok(problemsGetService.getProblemThumbnail(publishId, problemId));
+    }
+
+    @GetMapping("problem/child/{publishId}/{problemId}")
+    @Operation(summary = "문항에 포함된 새끼문항 정보 조회", description = "단계별로 풀어보기 이후 화면들에서 필요한 정보들을 조회합니다.")
+    public ResponseEntity<ChildProblemsClientGetResponse> getChildProblems(
+            @PathVariable Long publishId,
+            @PathVariable Long problemId
+    ) {
+        return ResponseEntity.ok(problemsGetService.getChildProblems(publishId, problemId));
     }
 }

--- a/src/main/java/com/moplus/moplus_server/client/problem/dto/response/ChildProblemsClientGetResponse.java
+++ b/src/main/java/com/moplus/moplus_server/client/problem/dto/response/ChildProblemsClientGetResponse.java
@@ -1,0 +1,19 @@
+package com.moplus.moplus_server.client.problem.dto.response;
+
+import com.moplus.moplus_server.domain.problem.domain.childProblem.ChildProblem;
+import com.moplus.moplus_server.domain.problem.domain.problem.Problem;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record ChildProblemsClientGetResponse(
+        String mainProblemImageUrl,
+        List<Long> childProblemIds
+) {
+    public static ChildProblemsClientGetResponse of(Problem problem) {
+        return ChildProblemsClientGetResponse.builder()
+                .mainProblemImageUrl(problem.getMainProblemImageUrl())
+                .childProblemIds(problem.getChildProblems().stream().map(ChildProblem::getId).toList())
+                .build();
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/client/problem/service/ProblemsGetService.java
+++ b/src/main/java/com/moplus/moplus_server/client/problem/service/ProblemsGetService.java
@@ -4,6 +4,7 @@ package com.moplus.moplus_server.client.problem.service;
 import com.moplus.moplus_server.admin.publish.domain.Publish;
 import com.moplus.moplus_server.client.problem.dto.response.AllProblemGetResponse;
 import com.moplus.moplus_server.client.problem.dto.response.ChildProblemClientGetResponse;
+import com.moplus.moplus_server.client.problem.dto.response.ChildProblemsClientGetResponse;
 import com.moplus.moplus_server.client.problem.dto.response.ProblemClientGetResponse;
 import com.moplus.moplus_server.client.problem.dto.response.ProblemFeedProgressesGetResponse;
 import com.moplus.moplus_server.client.problem.dto.response.ProblemClientThumbnailResponse;
@@ -234,5 +235,26 @@ public class ProblemsGetService {
         //문항 조회
         Problem problem = problemRepository.findByIdElseThrow(problemId);
         return ProblemClientThumbnailResponse.of(problemNumber + 1, problem);
+    }
+
+    @Transactional(readOnly = true)
+    public ChildProblemsClientGetResponse getChildProblems(Long publishId, Long problemId) {
+        // 발행 조회
+        Publish publish = publishRepository.findByIdElseThrow(publishId);
+        denyAccessToFuturePublish(publish);
+
+        // 문항 세트 조회
+        ProblemSet problemSet = problemSetRepository.findByIdElseThrow(publish.getProblemSetId());
+        List<Long> problemIds = problemSet.getProblemIds();
+
+        // 발행된 문항세트에 포함된 문항인지 검사
+        int problemNumber = problemIds.indexOf(problemId);
+        if (problemNumber == -1) {
+            throw new NotFoundException(ErrorCode.PROBLEM_NOT_FOUND_IN_PROBLEM_SET);
+        }
+
+        //문항 조회
+        Problem problem = problemRepository.findByIdElseThrow(problemId);
+        return ChildProblemsClientGetResponse.of(problem);
     }
 }


### PR DESCRIPTION
# 💡 Issue
- resolved: #111 

# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->
- 단계별로 풀어보기에 진입한 후, 새끼문항들을 조회하기 위한 ID들을 조회해요.
- 메인문항 이미지 보기 기능을 위해 메인문항 이미지도 포함했어요.
- 응답 데이터는 아래와 같아요.
```json
{
  "data": {
    "mainProblemImageUrl": "https://s3-moplus.s3.ap-northeast-2.amazonaws.com/problems/1/main-problem/d989f0a8-5249-4526-8602-b41a5fdcfcc7.jpg",
    "childProblemIds": [
      9,
      10
    ]
  }
}
```
