### PR TITLE
[hotfix] 월별 조회시 날짜별 진행도 결정 로직 수정

### DIFF
--- a/src/main/java/com/moplus/moplus_server/client/submit/dto/response/DayProgress.java
+++ b/src/main/java/com/moplus/moplus_server/client/submit/dto/response/DayProgress.java
@@ -11,11 +11,18 @@ public enum DayProgress {
         if (problemStatuses.isEmpty()) {
             return INCOMPLETE;
         }
-        else if (problemStatuses.contains(ProblemSubmitStatus.IN_PROGRESS)) {
-            return IN_PROGRESS;
-        }
-        else{
+        boolean allNotStarted = problemStatuses.stream()
+                .allMatch(status -> status == ProblemSubmitStatus.NOT_STARTED);
+
+        boolean allFinished = problemStatuses.stream()
+                .allMatch(status -> status == ProblemSubmitStatus.CORRECT || status == ProblemSubmitStatus.INCORRECT);
+
+        if (allNotStarted) {
+            return INCOMPLETE;
+        } else if (allFinished) {
             return COMPLETE;
+        } else {
+            return IN_PROGRESS;
         }
     }
 }


### PR DESCRIPTION
# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->
- 월별 조회시 날짜별 진행도 결정 로직을 수정했습니다.
- 해당 발행 날짜에 대해 모든 문항의 제출 상태가 시작전 -> 미완료
- 모든 문항이 맞음/틀림/다시맞춤 -> 완료
- 나머지 경우 -> 진행중

